### PR TITLE
DO NOT MERGE YET.  Enables use of phenogrid as an npm module.

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,2 @@
+#rm -rf ./node_modules
+rm -rf dist/

--- a/css/instructions.css
+++ b/css/instructions.css
@@ -1,0 +1,103 @@
+/**These styles are specific to the widgets instruction page (templates/page/widgets.mustache)*/
+body{
+	margin-left:25px;
+	width:100%;
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 14px;
+}
+
+ol.li, .title, .sectiontitle, h1, .subsectiontitle, .header{
+	font-weight:bold;
+	color:#44A293;
+} 
+
+.header{
+	border-top: 0px solid black;
+	
+	padding-bottom:15px;
+}
+
+.title{
+	font-size: 1.8em;
+	font-weight:bold;
+}
+
+
+#viscontent .shortselects {
+    left: 770px;
+    top: 450px;
+}
+
+.shortselects {
+    top: 360x;
+}
+
+
+subsectiontitle{
+	font-size:1.0em;
+}
+		
+
+#title{
+	float:left;
+
+}
+
+#text {
+    clear:both;
+}
+	     
+
+#title b{
+//  position:absolute;
+  top:100px;
+  left:73px;
+}
+
+#title2{
+	
+	float:left;
+//	position: absolute;
+	top:130px;
+	left:72px;
+}
+#organism_div {  
+//	position:absolute;
+	top:97px;
+	left:610px;
+}
+.wrapperforfooter .title{
+    font-size: 32px;
+}
+
+#calculation_div {
+//	position:absolute;
+	top:130px;
+	left:620px; 
+}
+
+#phencontent{
+	top: -20px;
+	position: relative;
+}
+.headtitle img{
+	vertical-align:bottom;
+}
+
+li{ padding-bottom: 7px;}
+
+div .title{
+//	margin-top:-410px;
+	clear:both;
+}
+
+#viscontent { 
+    height: 350px;
+    width: 100%;
+    clear: both;
+}
+
+#footer {
+	margin-top: 20px;
+}
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,27 +29,16 @@ var paths = {
 };
 
 // The default task is to build the different distributions.
-gulp.task('bundle', ['browserify-byo', 'create-bundle']);
+gulp.task('bundle', ['browserify-byo']);
 
 // Bundle together 
 gulp.task('browserify-byo', function(cb) {
     browserify('./js/phenogrid.js')
 	.bundle()
-        .pipe(source('./js/phenogrid.js'))
+    .pipe(source('./js/phenogrid.js'))
 	.pipe(rename('phenogrid-byo.js'))
 	.pipe(gulp.dest('./dist/'))
 	.on('end', cb);
-});
-
-// Cat on the used jquery to the bundle.
-gulp.task('create-bundle', ['browserify-byo'], function() {
-    var pkg = require('./package.json');
-    var jq_path = pkg['browser']['jquery'];
-    //var jqui_path = pkg['browser']['jquery-ui'];
-    gulp.src([jq_path, 'dist/phenogrid-byo.js'])
-    //gulp.src(['./dist/phenogrid-byo.js'])
-	.pipe(concat('phenogrid-bundle.js'))
-	.pipe(gulp.dest('./dist/'));
 });
 
 // Browser runtime environment construction.
@@ -118,8 +107,8 @@ gulp.task('release', ['build', 'publish-npm']);
 gulp.task('publish-npm', function() {
     var npm = require("npm");
     npm.load(function (er, npm) {
-	// NPM
-	npm.commands.publish();	
+    // NPM
+    npm.commands.publish();
     });
 });
 

--- a/index.html
+++ b/index.html
@@ -2,18 +2,10 @@
 <head>
 <title>Monarch Phenotype Grid Widget</title>
 
-<!-- Option 1 Begin -->
-<!-- When jquery.js is already loaded in your target page -->
-<!--<script src="PATH_TO_YOUR/jquery/dist/jquery.js"></script>-->
-<!--<script src="dist/phenogrid-byo.js"></script>-->
-<!-- Option 1 End -->
-
-<!-- Option 2 Begin -->
-<!-- When jquery.js is not loaded in your target page -->
-<script src="dist/phenogrid-bundle.js"></script>
-<!-- Option 2 End -->
+<!-- Version comment 1 -->
 
 <script src="config/phenogrid_config.js"></script>
+<script charset="UTF-8" src="dist/phenogrid-byo.js"></script>
 
 <link rel="stylesheet" type="text/css" href="css/font-awesome.css"/>
 <link rel="stylesheet" type="text/css" href="css/normalize.css"/>
@@ -37,21 +29,21 @@ var phenotypes = [
 	{ id:"HP:0002172", observed:"positive"},
 	{ id:"HP:0002322", observed:"positive"},
 	{ id:"HP:0007159", observed:"positive"}
-];	
+];
 
-$(document).ready(function(){
-	$("#phenogrid_container").phenogrid({
-		serverURL :"http://beta.monarchinitiative.org", 
+function initializePhenogrid(element) {
+	Phenogrid.createPhenogridForElement(element, {
+		serverURL : "http://beta.monarchinitiative.org",
 		phenotypeData: phenotypes,
-		targetSpeciesName: "Mus musculus" 
+		targetSpeciesName: "Mus musculus"
 	});
-});
+}
 
 </script>
 
 </head>
 
-<body>
+<body onload="initializePhenogrid(document.getElementById('phenogrid_container'))">
 
 <div id="phenogrid_container"></div>
 

--- a/js/stickytooltip.js
+++ b/js/stickytooltip.js
@@ -4,6 +4,8 @@
 * Visit http://www.dynamicdrive.com/ for full source code
 */
 
+var jQuery = require('jQuery');
+var $ = jQuery;
 
 var stickytooltip={
 	tooltipoffsets: [1, -1], //additional x and y offset from mouse cursor for tooltips 0,-3  [10, 10]

--- a/package.json
+++ b/package.json
@@ -1,67 +1,53 @@
 {
-    "name":"phenogrid",
-    "version":"0.0.1",
-    "description":"Monarch PhenoGrid widget",
-    "repository":{
-        "type":"git",
-        "url":"https://github.com/monarch-initiative/phenogrid.git"
-    },
-    "keywords":[
-        "monarch",
-        "phenogrid",
-        "widget",
-        "visualization"
-    ],
-    "author":"University of Pittsburgh, Department of Biomedical Informatics",
-    "license":"ISC",
-    "bugs":{
-        "url":"https://github.com/monarch-initiative/phenogrid/issues"
-    },
-    "homepage":"https://github.com/monarch-initiative/phenogrid",
-    "dependencies":{
-        "browserify-shim":"^3.8.8",
-        "d3":"^3.5.5",
-        "jquery":"^2.1.4",
-        "jquery-ui":"^1.10.5",
-        "jshashtable":"^0.1.0",
-        "vinyl-source-stream":"^1.1.0"
-    },
-    "browser":{
-        "jquery":"./node_modules/jquery/dist/jquery.js",
-        "jquery-ui":"./node_modules/jquery-ui/jquery-ui.js",
-        "d3":"./node_modules/d3/d3.min.js"
-    },
-    "devDependencies":{
-        "browserify":"^10.2.1",
-        "chai":"^2.3.0",
-        "del":"^1.1.1",
-        "gulp":"^3.8.11",
-        "gulp-bump":"^0.3.0",
-        "gulp-concat":"^2.5.2",
-        "gulp-git":"^1.2.3",
-        "gulp-jsdoc":"^0.1.4",
-        "gulp-mocha":"^2.0.1",
-        "gulp-pandoc":"^0.2.1",
-        "gulp-rename":"^1.2.2",
-        "gulp-shell":"^0.4.2",
-        "gulp-uglify":"^1.2.0",
-        "jsdoc":"^3.3.0",
-        "jsdoc-baseline":"git://github.com/hegemonic/jsdoc-baseline.git#74d1dc8075"
-    },
-    "browserify":{
-        "transform":[
-            "browserify-shim"
-        ]
-    },
-    "browserify-shim":{
-        "jquery":{
-            "exports":"global:$"
-        },
-        "jquery-ui":{
-            "depends":[
-                "jquery"
-            ]
-        }
-    },
-    "main":"js/phenogrid.js"
+  "name": "phenogrid",
+  "version": "0.0.2",
+  "description": "Monarch PhenoGrid widget",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/monarch-initiative/phenogrid.git"
+  },
+  "keywords": [
+    "monarch",
+    "phenogrid",
+    "widget",
+    "visualization"
+  ],
+  "author": "University of Pittsburgh, Department of Biomedical Informatics",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/monarch-initiative/phenogrid/issues"
+  },
+  "homepage": "https://github.com/monarch-initiative/phenogrid",
+  "dependencies": {
+    "browserify-global-shim": "^1.0.0",
+    "browserify-shim": "^3.8.8",
+    "d3": "^3.5.5",
+    "jquery": "^2.1.4",
+    "jquery-ui": "^1.10.5",
+    "jshashtable": "^0.1.0",
+    "npm": "^2.12.1",
+    "vinyl-source-stream": "^1.1.0"
+  },
+  "browser": {
+  },
+  "devDependencies": {
+    "browserify": "^10.2.1",
+    "chai": "^2.3.0",
+    "del": "^1.1.1",
+    "gulp": "^3.8.11",
+    "gulp-bump": "^0.3.0",
+    "gulp-concat": "^2.5.2",
+    "gulp-git": "^1.2.3",
+    "gulp-jsdoc": "^0.1.4",
+    "gulp-mocha": "^2.0.1",
+    "gulp-pandoc": "^0.2.1",
+    "gulp-rename": "^1.2.2",
+    "gulp-shell": "^0.4.2",
+    "gulp-uglify": "^1.2.0",
+    "jsdoc": "^3.3.0",
+    "jsdoc-baseline": "git://github.com/hegemonic/jsdoc-baseline.git#74d1dc8075"
+  },
+  "browserify": {
+  },
+  "main": "js/phenogrid.js"
 }


### PR DESCRIPTION
DO NOT MERGE YET. PR IS FOR REFERENCE PURPOSES. WAITING FOR BRANCH ZY TO MERGE FIRST.

Removes create-bundle from gulpfile.js, as it is no longer necessary.

Changes index.html to only use phenogrid-byo.js and to use standard HTML and the Phenogrid Javascript API exposed by phenogrid.js.

Fixes _getResourceUrl to detect whether it is dealing with an old /widgets/phenogrid server or a new /node_modules/phenogrid server.

Replace the use of scriptPath with imagePath, which points directly to the /image directory instead of relying upon ../image, which pup_tent can't handle properly.

require jQuery in stickytooltip.js

Eliminate the browserify-shim: usage in package.json, it is no longer necessary. Similarly, the use of the browser: field is not necessary, so has been eliminated.