### PR TITLE
Fixes package.json to not refer to browerify-*-shim. This change was lost from my previous PR during the manual merge.

### DIFF
--- a/dist/phenogrid-bundle.css
+++ b/dist/phenogrid-bundle.css
@@ -2765,7 +2765,6 @@ stroke: #000;
 stroke-width: 2;
 }
 
-
 .pg_row_accent,
 .pg_col_accent {
 /*stroke:#ea763b;*/

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     },
     "homepage":"https://github.com/monarch-initiative/phenogrid",
     "dependencies":{
-        "browserify-global-shim": "^1.0.0",
-		"browserify-shim":"^3.8.8",
         "d3":"^3.5.5",
         "jquery":"^2.1.4",
         "jquery-ui":"^1.10.5",

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,4 @@
+rm -rf ./node_modules
+rm -rf dist/
+npm install
+gulp bundle


### PR DESCRIPTION
Fixes package.json to not refer to browerify-*-shim. This change was lost from my previous PR during the manual merge.
Adds rebuild.sh that simplifies rebuilding of phenogrid, ensuring a clean slate prior to making a new distribution. Primarily for phenogrid developer use.

