### PR TITLE
Fixes gulp workflow and index.html so that README.md is the authorita…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 #About Phenogrid
 
-Phenogrid is implemented as a jQuery UI widget. The phenogrid widget uses semantic similarity calculations provided by OWLSim (www.owlsim.org), as provided through APIs from the Monarch Initiative (www.monarchinitiative.org).
+Phenogrid is a Javascript component that visualizes semantic similarity calculations provided by OWLSim (www.owlsim.org), as provided through APIs from the Monarch Initiative (www.monarchinitiative.org).
 
 Given an input list of phenotypes (you will see the sample input below) and parameters specified in config/phenogrid_config.js indicating desired source of matching models (humans, model organisms, etc.), the phenogrid will call the Monarch API to get OWLSim results and render them in your web browser in data visualization. And you may use the visualized data for your research.
 
 #Installation Instructions
 
-If you won't be doing any development of Phenogrid, you can simply download the phenogrid github zip file and unzip, then open the `index.html` to run this widget. 
+If you won't be doing any development of Phenogrid, you can simply download the phenogrid github zip file and unzip, then open the `index.html` to run this widget.
 
 For developers who want to make changes to phenogrid, following is the process.
 
@@ -15,6 +15,7 @@ For developers who want to make changes to phenogrid, following is the process.
 Before you get started, you will need to make sure you have npm
 installed first. npm is bundled and installed automatically with
 node.js. If you have not installed node.js, try:
+
 ```
 curl -sL https://rpm.nodesource.com/setup | bash -
 
@@ -28,7 +29,7 @@ Or, just visit nodejs.org.
 
 ##2. Install phenogrid widget
 
-To download and install the phenogrid widget, run  
+To download and install the phenogrid widget, run
 
 ```
 npm install
@@ -51,7 +52,7 @@ gulp bundle
 
 This command will use browserify to bundle up phenogrid core and its
 dependencies into `phenogrid-bundle.js` and create the merge
-`phenogrid-bundle.css` and put both files under `dist` folder. 
+`phenogrid-bundle.css` and put both files under `dist` folder.
 
 ##4. Add phenogrid in your target page
 
@@ -59,9 +60,9 @@ In the below sample code, you will see how to use phenogrid as a
 embeded widget in your HTML. Please note that in order to parse the js
 file correctly (since it uses D3.js and D3.js requires UTF-8 charset
 encoding), we suggest you to add the `<meta charset="UTF-8">` tag in
-your HTML head. 
+your HTML head.
 
-````html
+```html
 <html>
 <head>
 <meta charset="UTF-8">
@@ -89,7 +90,7 @@ var phenotypes = [
 	{id:"HP:0002172", observed:"positive"},
 	{id:"HP:0002322", observed:"positive"},
 	{id:"HP:0007159", observed:"positive"}
-];	
+];
 
 window.onload = function() {
     Phenogrid.createPhenogridForElement(document.getElementById('phenogrid_container'), {
@@ -108,7 +109,7 @@ window.onload = function() {
 
 </body>
 </html>
-````
+```
 
 #Configuration Parameters
 

--- a/css/print.css
+++ b/css/print.css
@@ -1,0 +1,234 @@
+@media print {
+    * {
+        background: transparent !important;
+        color: #000 !important; /* Black prints faster: h5bp.com/s */
+        box-shadow: none !important;
+        text-shadow: none !important;
+    }
+
+    a,
+    a:visited {
+        text-decoration: underline;
+    }
+
+    /* Disabled by PotatoGuide
+    a[href]:after {
+        content: " (" attr(href) ")";
+    }
+
+    abbr[title]:after {
+        content: " (" attr(title) ")";
+    }
+    */
+
+    /*
+     * Don't show links for images, or javascript/internal links
+     */
+
+    a[href^="javascript:"]:after,
+    a[href^="#"]:after {
+        content: "";
+    }
+
+    pre,
+    blockquote {
+        border: 1px solid #999;
+        page-break-inside: avoid;
+    }
+
+    thead {
+        display: table-header-group; /* h5bp.com/t */
+    }
+
+    tr,
+    img {
+        page-break-inside: avoid;
+    }
+
+    img {
+        max-width: 100% !important;
+    }
+
+    p,
+    h2,
+    h3 {
+        orphans: 3;
+        widows: 3;
+    }
+
+    h2,
+    h3 {
+        page-break-after: avoid;
+    }
+
+    /* PotatoGuide */
+    .print_hide {
+        display: none !important;
+    }
+
+    .print_show {
+        display: inherit !important;
+    }
+
+}
+
+/*--------------------------------------------------------------
+Application-specific Styles
+-------------------------------------------------------------- */
+html {
+overflow-y:scroll;
+font-size: 62.5%; /* 16*62.5%=10px */
+-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+body {
+font-family: 'Source Sans Pro', sans-serif;
+font-size: 16px;
+line-height: 1.428571429;
+color: #212425;
+background:#fff;
+}
+
+/* clearfix hack http://nicolasgallagher.com/micro-clearfix-hack/ */
+.clearfix:before,
+.clearfix:after {
+content: " "; /* 1 */
+display: table; /* 2 */
+}
+
+.clearfix:after {
+clear: both;
+}
+
+.pg_index{
+width:1020px;
+margin:0 auto;
+padding:0;
+}
+
+#phenogrid_container{
+border:1px solid #ddd;
+margin:40px 0;
+}
+
+code{
+padding: 2px 4px;
+font-size: 90%;
+color: #DC4945;
+white-space: nowrap;
+background-color: #f9f2f4;
+border-radius: 4px;
+}
+
+/* Table */
+.table {
+width:100%;
+border:1px solid #ccc;
+margin:20px 0;
+}
+
+.table th {
+line-height:1.6;
+padding:15px 10px;
+background:#f8f8f8;;
+border:1px solid #ddd;
+/* The text in th are bold and centered by default. */
+}
+
+.table td {
+line-height:1.6;
+padding:10px;
+border:1px solid #ccc;
+}
+
+.table_hover>tbody>tr:hover>td{
+background-color:#fefbd6;
+}
+
+
+/*--------------------------------------------------------------
+syntac highlighter
+-------------------------------------------------------------- */
+.syntax  {
+font-size: 14px;
+background: #f8f8f8;
+border:1px solid #ddd;
+padding:15px 20px;
+margin:10px 0;
+overflow-x:auto;
+font-family:Menlo,'Courier New',Courier,monospace;
+position:relative;
+}
+
+.source_badge{
+position:absolute;
+right:0;
+top:0;
+border-left:1px solid #ddd;
+border-bottom:1px solid #ddd;
+background:#fffecf;
+padding:5px 10px;
+text-align:center;
+font-size:.8em;
+}
+
+.syntax .c { color: #408080; font-style: italic } /* Comment */
+.syntax .err { border: 1px solid #FF0000 } /* Error */
+.syntax .k { color: #008000; font-weight: bold } /* Keyword */
+.syntax .o { color: #666666 } /* Operator */
+.syntax .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.syntax .cp { color: #BC7A00 } /* Comment.Preproc */
+.syntax .c1 { color: #408080; font-style: italic } /* Comment.Single */
+.syntax .cs { color: #408080; font-style: italic } /* Comment.Special */
+.syntax .gd { color: #A00000 } /* Generic.Deleted */
+.syntax .ge { font-style: italic } /* Generic.Emph */
+.syntax .gr { color: #FF0000 } /* Generic.Error */
+.syntax .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.syntax .gi { color: #00A000 } /* Generic.Inserted */
+.syntax .go { color: #808080 } /* Generic.Output */
+.syntax .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.syntax .gs { font-weight: bold } /* Generic.Strong */
+.syntax .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.syntax .gt { color: #0040D0 } /* Generic.Traceback */
+.syntax .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.syntax .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.syntax .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.syntax .kp { color: #008000 } /* Keyword.Pseudo */
+.syntax .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.syntax .kt { color: #B00040 } /* Keyword.Type */
+.syntax .m { color: #666666 } /* Literal.Number */
+.syntax .s { color: #BA2121 } /* Literal.String */
+.syntax .na { color: #7D9029 } /* Name.Attribute */
+.syntax .nb { color: #008000 } /* Name.Builtin */
+.syntax .nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.syntax .no { color: #880000 } /* Name.Constant */
+.syntax .nd { color: #AA22FF } /* Name.Decorator */
+.syntax .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.syntax .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.syntax .nf { color: #0000FF } /* Name.Function */
+.syntax .nl { color: #A0A000 } /* Name.Label */
+.syntax .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.syntax .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.syntax .nv { color: #19177C } /* Name.Variable */
+.syntax .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.syntax .w { color: #bbbbbb } /* Text.Whitespace */
+.syntax .mf { color: #666666 } /* Literal.Number.Float */
+.syntax .mh { color: #666666 } /* Literal.Number.Hex */
+.syntax .mi { color: #666666 } /* Literal.Number.Integer */
+.syntax .mo { color: #666666 } /* Literal.Number.Oct */
+.syntax .sb { color: #BA2121 } /* Literal.String.Backtick */
+.syntax .sc { color: #BA2121 } /* Literal.String.Char */
+.syntax .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.syntax .s2 { color: #BA2121 } /* Literal.String.Double */
+.syntax .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.syntax .sh { color: #BA2121 } /* Literal.String.Heredoc */
+.syntax .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.syntax .sx { color: #008000 } /* Literal.String.Other */
+.syntax .sr { color: #BB6688 } /* Literal.String.Regex */
+.syntax .s1 { color: #BA2121 } /* Literal.String.Single */
+.syntax .ss { color: #19177C } /* Literal.String.Symbol */
+.syntax .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.syntax .vc { color: #19177C } /* Name.Variable.Class */
+.syntax .vg { color: #19177C } /* Name.Variable.Global */
+.syntax .vi { color: #19177C } /* Name.Variable.Instance */
+.syntax .il { color: #666666 } /* Literal.Number.Integer.Long */

--- a/dist/phenogrid-bundle.js
+++ b/dist/phenogrid-bundle.js
@@ -26,9 +26,9 @@ module.exports = {
 /*
  * Phenogrid
  *
- * Phenogrid is implemented as a jQuery UI widget. The phenogrid widget uses semantic similarity calculations provided 
+ * Phenogrid is implemented as a jQuery UI widget. The phenogrid widget uses semantic similarity calculations provided
  * by OWLSim (www.owlsim.org),  as provided through APIs from the Monarch Initiative (www.monarchinitiative.org).
- * 
+ *
  * Phenogrid widget can be instantiated on a jquery-enabled web page with a call of the form
  *
  * window.onload = function() {
@@ -38,7 +38,7 @@ module.exports = {
  *         targetSpeciesName: "Mus musculus"
  *     });
  * }
- * 
+ *
  * 'phenogrid_container' is the id of the div that will contain the phenogrid widget
  *	phenotypes is a Javascript array of objects listing the phenotypes to be rendered in the widget, it takes one of two forms:
  *
@@ -77,7 +77,7 @@ module.exports = {
 // Will need to install jquery, jquery-ui, d3, jshashtable first via npm - Joe
 // Note: jquery 2.1.0 is capable of using browserify's module.exports - Joe
 // npm install jquery jquery-ui d3 jshashtable
- 
+
 // NPM installed packages, you will find them in /node_modules - Joe
 
 // jquery  is commonsJS compliant as of 2.1.0 - Joe
@@ -104,7 +104,7 @@ var TooltipRender = require('./render.js');
 	} else {
 		factory($, window, document);
 	}
-})  
+})
 
 (function($, window, document, __undefined__) {
 	var createPhenogridForElement = function(element, options) {
@@ -115,7 +115,7 @@ var TooltipRender = require('./render.js');
 	window.Phenogrid = {
 		createPhenogridForElement: createPhenogridForElement
 	};
-	
+
 	// Use widget factory to define the UI plugin - Joe
 	// Can aslo be ns.phenogrid (ns can be anything else - namespace) - Joe
 	// Later can be called using $().phenogrid(); - Joe
@@ -123,9 +123,9 @@ var TooltipRender = require('./render.js');
 	$.widget("ui.phenogrid", {
 
 		// Why not prefixed with underscore? - Joe
-		
+
 		// core commit. Not changeable by options.
-		
+
 		// merged into this.state - Joe
 		// only used twice, one of them is for config.h, which according to the comments, h should be elimiated - Joe
 		// so we can just use one variable for all configs to contain everything in congig and internalOptions - Joe
@@ -166,7 +166,7 @@ var TooltipRender = require('./render.js');
 			comparisonTypes: [{organism: "Homo sapiens", comparison: "diseases"}],
 			defaultComparisonType: {comparison: "genes"},
 			// speciesLabels Not used - Joe
-			speciesLabels: [ 
+			speciesLabels: [
 				{abbrev: "HP", label: "Human"},
 				{abbrev: "MP", label: "Mouse"},
 				{abbrev: "ZFIN", label: "Zebrafish"},
@@ -177,7 +177,7 @@ var TooltipRender = require('./render.js');
 			],
 			dataDisplayCount: 30,
 			labelCharDisplayCount : 20,
-			apiEntityMap: [ 
+			apiEntityMap: [
 				{prefix: "HP", apifragment: "disease"},
 				{prefix: "OMIM", apifragment: "disease"}
 			],
@@ -198,7 +198,7 @@ var TooltipRender = require('./render.js');
 		},
 
 		// Why not prefixed with underscore? - Joe
-		
+
 		// merged into this.state - Joe
 		// only used once, so we can just use one variable to store all configs - Joe
 		internalOptions: {
@@ -221,7 +221,7 @@ var TooltipRender = require('./render.js');
 						{name: "Mus musculus", taxon: "10090" },
 						{name: "Danio rerio", taxon: "7955"},
 						{name: "Drosophila melanogaster", taxon: "7227"},
-						{name: "UDP", taxon: "UDP"} 
+						{name: "UDP", taxon: "UDP"}
 					],
 			// According to Harry, the genotype expand is not showing in current version - Joe
 			genotypeExpandLimit: 5, // sets the limit for the number of genotype expanded on grid
@@ -230,14 +230,14 @@ var TooltipRender = require('./render.js');
 			providedData: {}
 		},
 
-		
-		
-		
+
+
+
 		// Methods begin with underscore are not callable from outside of the plugin - Joe
-		
-		
-		
-		
+
+
+
+
 		// reset state values that must be cleared before reloading data
 		_reset: function(type) {
 			// LEAVE UNTIL OR MOVING HASH CONSTRUCTION EARLIER
@@ -344,14 +344,14 @@ var TooltipRender = require('./render.js');
 			return species;
 		},
 
-		
-		
-		
+
+
+
 		// _create() method is the widget's constructor, it is called for each element that the plugin method is called on - Joe
-		
-		
-		
-		
+
+
+
+
 		// NOTE: I'm not too sure what the default init() method signature should be given an imageDiv and phenotype_data list
 		/*
 		 * imageDiv - the place you want the widget to appear
@@ -361,35 +361,35 @@ var TooltipRender = require('./render.js');
 		 * [ "HP:12345", "HP:23451", ...]
 		 */
 		_create: function() {
-			
-			
-			
-			
-			
-			
-			
+
+
+
+
+
+
+
 			// local model.js into local scope - Joe
-			//this.model = model; 
-			
-			
-			
-			
-			
-			
-			
-			
-			
+			//this.model = model;
+
+
+
+
+
+
+
+
+
 			// must be available from js loaded in a separate file...
 			// configoptions is defined in phenogrid_config.js - Joe
-			
+
 			/* Content of phenogrid_config.js, just a copy for quick reference - Joe
-			
+
 			var configoptions = {
 				"serverURL": "",
 				"selectedCalculation": "0",
 				"invertAxis": false,
 				"selectedSort": "Frequency",
-				"targetSpeciesName" : "Overview",			   
+				"targetSpeciesName" : "Overview",
 				"refSpecies": "Homo sapiens",
 				"targetSpeciesList" : [
 					{ "name": "Homo sapiens", "taxon": "9606"},
@@ -401,30 +401,30 @@ var TooltipRender = require('./render.js');
 			*/
 
 			// loaded into local scope, should just remove the phenogrid_config.js and have those config options coded in this file. - Joe
-			this.configoptions = configoptions; 
+			this.configoptions = configoptions;
 			// check these
 			// important that config options (from the file) and this. options (from
 			// the initializer) come last
-			
+
 			// jquery $.extend(): Merge the contents of two or more objects together into the first object - Joe
 			// so now this.state contains all the config options - Joe
 			this.state = $.extend({}, this.internalOptions, this.config, this.configoptions, this.options);
-			
+
 			// Added by Joe - Joe
 			// simsearch returned data b[] is stored in this.state['data'] - Joe
-			console.log(this.state); 
-			
-			
+			console.log(this.state);
+
+
 			// Do we need this? - Joe
-			
+
 			// default simServerURL value..
 			if (typeof(this.state.simServerURL) == 'undefined' || this.state.simServerURL === '') {
 				this.state.simServerURL=this.state.serverURL;
 			}
-			
+
 			// contains all simsearch returned data - Joe
 			this.state.data = {};
-			
+
 			// will this work?
 			this.configoptions = undefined; // Did you want to reset this variable? Why only reset configoptions? - Joe
 
@@ -458,7 +458,7 @@ var TooltipRender = require('./render.js');
 		 * thus, a workaround is included below to set the path correctly if it come up as '/'.
 		 * this should not impact any standalone uses of phenogrid, and will be removed once monarch-app is cleaned up.
 		 */
-		 
+
 		/*
 		 * HACK WARNING - 20150713, dan@quantumclay.com
 		 * 	The serverURL corresponds to a running Monarch server that can provide 'help text'
@@ -472,7 +472,7 @@ var TooltipRender = require('./render.js');
 		 *	Currently, the existence of an explicit serverUrl (non-blank) is used to indicate that the
 		 *	workaround is necessary.
 		 */
-		 
+
 		 /*
 		 * HACK WARNING - 20150715, zhy19@pitt.edu
 		 * 	Added htmlPath to refer to the relative path to those FAQ html pages
@@ -484,12 +484,12 @@ var TooltipRender = require('./render.js');
 			return this.state.htmlPath + name + '.' + type;
 		},
 
-		
-		
+
+
 		// initialization, distinct from creation - Joe
-		
-		
-		
+
+
+
 		//init is now reduced down completely to loading
 		_init: function() {
 			this.element.empty();
@@ -519,7 +519,7 @@ var TooltipRender = require('./render.js');
 				this.state.stickyInitialized = true;
 				stickytooltip.init("*[data-tooltip]", "mystickytooltip");
 			}
-			
+
 			this.state.tooltipRender = new TooltipRender(this.state.serverURL);
 
 			if (this.state.owlSimFunction == 'exomiser') {
@@ -623,11 +623,11 @@ var TooltipRender = require('./render.js');
 			}
 		},
 
-		
-		
+
+
 		// https://api.jqueryui.com/jquery.widget/#method-_setOption - Joe
-		
-		
+
+
 		/* dummy option procedures as per
 		 * http://learn.jquery.com/jquery-ui/widget-factory/how-to-use-the-widget-factory/
 		 * likely to have some content added as we proceed
@@ -664,10 +664,10 @@ var TooltipRender = require('./render.js');
 				.append("rect")
 				.attr("id", "pg_gridline")
 				.attr("transform", "translate(254, " + (this.state.yModelRegion + 5) + ")") // position the pg_gridline net to region - Joe
-				.attr("x", function(d, i) { 
+				.attr("x", function(d, i) {
 					return d[1] * mWidth;
 				})
-				.attr("y", function(d, i) { 
+				.attr("y", function(d, i) {
 					return d[0] * mHeight;
 				})
 				.attr("class", "hour bordered deselected")
@@ -740,10 +740,10 @@ var TooltipRender = require('./render.js');
 				.append("rect")
 				.attr("transform", modelRectTransform)
 				.attr("class", "mini_model")
-				.attr("y", function(d, i) { 
+				.attr("y", function(d, i) {
 					return self.state.smallYScale(d.yID) + linePad / 2;
 				})
-				.attr("x", function(d) { 
+				.attr("x", function(d) {
 					return self.state.smallXScale(d.xID) + linePad / 2;
 				})
 				.attr("width", linePad)
@@ -786,7 +786,7 @@ var TooltipRender = require('./render.js');
 						var curY = parseFloat(current.attr("y"));
 
 						var rect = self.state.svg.select("#pg_selectionrect");
-						
+
 						rect.attr("transform", "translate(0, 0)"); // May not need this - Joe
 
 						// limit the range of the x value
@@ -889,7 +889,7 @@ var TooltipRender = require('./render.js');
 				var tipTextLength = 92;
 				var explYOffset = 15;
 				var explXOffset = 10;
-				
+
 				var scoretip = self.state.svg.append("text")
 					.attr("transform", "translate(" + (self.state.axis_pos_list[2] ) + "," + scoreTipY + ")")
 					.attr("x", 0)
@@ -900,7 +900,7 @@ var TooltipRender = require('./render.js');
 				var tip	= self.state.svg
 					.append("text")
 					.attr('font-family', 'FontAwesome')
-					.text(function(d) { 
+					.text(function(d) {
 						return '\uF05A\n'; // Need to convert HTML/CSS unicode to javascript unicode - Joe
 					})
 					.attr("id", "modelscores")
@@ -918,7 +918,7 @@ var TooltipRender = require('./render.js');
 					.attr("class", "pg_tip")
 					.text("Best matches high to low"); // uppercased best - > Best - Joe
 			}
-			
+
 		},
 
 		// Overview navigation - Joe
@@ -937,7 +937,7 @@ var TooltipRender = require('./render.js');
 
 			// There's better way to create this two-line text - Joe
 			// SVG 1.2 supports textarea, not all browsers support it though - Joe
-			
+
 			var y = self.state.yModelRegion + overviewBoxDim + overviewInstructionHeightOffset;
 			var rect_instructions = self.state.svg.append("text")
 				.attr("x", self.state.axis_pos_list[2] + 10)
@@ -964,12 +964,12 @@ var TooltipRender = require('./render.js');
 
 			this.state.smallYScale = d3.scale.ordinal()
 				.domain(sortDataList.map(function (d) {
-					return d; 
+					return d;
 				}))
 				.rangePoints([0,overviewRegionSize]);
 
 			var modids = mods.map(function (d) {
-				return d; 
+				return d;
 			});
 			this.state.smallXScale = d3.scale.ordinal()
 				.domain(modids)
@@ -1142,12 +1142,12 @@ var TooltipRender = require('./render.js');
 			this.state.phenotypeListHash = new Hashtable();
 			this.state.modelListHash = new Hashtable();
 			// Create a new empty hash table with supplied options, Hashtable(Object options) - Joe
-			// hashCode: A function that provides hash codes for keys placed in the hash table. 
-			// equals: A function that checks for equality between two keys with the same hash code. 
+			// hashCode: A function that provides hash codes for keys placed in the hash table.
+			// equals: A function that checks for equality between two keys with the same hash code.
 			//this.state.modelDataHash = new Hashtable({hashCode: this.model.modelDataPointPrint, equals: this.model.modelDataPointEquals});
 			this.state.modelDataHash = new Hashtable({hashCode: model.modelDataPointPrint, equals: model.modelDataPointEquals});
 
-			
+
 			// [vaa12] determine if is wise to preload datasets for the three species and then build overview from this
 			// At time being, overview is made up of three calls, which it repeats these calls with a larger limit if you decided to view single species
 			// Might be more efficent to load those three, cache them and then make an overview dataset and cache that as well.
@@ -1215,7 +1215,7 @@ var TooltipRender = require('./render.js');
 			var toadd = limit - res.b.length;
 			for (var i = 0; i < toadd; i++) {
 				var dummyId = "dummy" + species + i;
-				var newItem = { 
+				var newItem = {
 					id: dummyId,
 					label: this.state.dummyModelName,
 					score: {score: 0, rank: Number.MAX_VALUE},
@@ -1285,12 +1285,12 @@ var TooltipRender = require('./render.js');
 						}
 
 						hashData = {
-							"label": item.label, 
-							"species": species, 
-							"taxon": item.taxon.id, 
-							"type": type, 
-							"pos": parseInt(posID), 
-							"rank": parseInt(idx), 
+							"label": item.label,
+							"species": species,
+							"taxon": item.taxon.id,
+							"type": type,
+							"pos": parseInt(posID),
+							"rank": parseInt(idx),
 							"score": item.score.score
 						};
 						// use put(key, value) to add a key/value pair to the hashtable, and get() to retrieve a value - Joe
@@ -1389,20 +1389,20 @@ var TooltipRender = require('./render.js');
 						modelPoint = new model.modelDataPoint(this._getConceptId(modelID), this._getConceptId(curr_row.a.id));
 					}
 					this._updateSortVals(this._getConceptId(curr_row.a.id), parseFloat(curr_row.lcs.IC));
-					
+
 					// simsearch returns array b:[{}...] with all the matched results. Each item in array b is an object
 					// that contains: id, label, matches[], score{}, taxon{}, and type. - Joe
-					
+
 					hashData = {
-						"value": lcs, 
-						"subsumer_label": curr_row.lcs.label, 
-						"subsumer_id": this._getConceptId(curr_row.lcs.id), 
-						"subsumer_IC": parseFloat(curr_row.lcs.IC), 
-						"b_label": curr_row.b.label, 
-						"b_id": this._getConceptId(curr_row.b.id), 
+						"value": lcs,
+						"subsumer_label": curr_row.lcs.label,
+						"subsumer_id": this._getConceptId(curr_row.lcs.id),
+						"subsumer_IC": parseFloat(curr_row.lcs.IC),
+						"b_label": curr_row.b.label,
+						"b_id": this._getConceptId(curr_row.b.id),
 						"b_IC": parseFloat(curr_row.b.IC)
 					};
-					
+
 					this.state.modelDataHash.put(modelPoint, hashData);
 				}
 			}
@@ -1475,8 +1475,8 @@ var TooltipRender = require('./render.js');
 				return this.state.yAxis.get(key);
 			} else if (this.state.xAxis.containsKey(key)) {
 				return this.state.xAxis.get(key);
-			} else { 
-				return false; 
+			} else {
+				return false;
 			}
 		},
 
@@ -1486,8 +1486,8 @@ var TooltipRender = require('./render.js');
 				return 'Model';
 			} else if (this.state.phenotypeListHash.containsKey(key)) {
 				return 'Phenotype';
-			} else { 
-				return false; 
+			} else {
+				return false;
 			}
 		},
 
@@ -1543,9 +1543,9 @@ var TooltipRender = require('./render.js');
 			for (var i in origHash){
 				if(!origHash.hasOwnProperty(i)){break;}
 				newHash.push({
-					"id": origHash[i][0], 
-					"label": origHash[i][1].label.toLowerCase(), 
-					"count": origHash[i][1].count, 
+					"id": origHash[i][0],
+					"label": origHash[i][1].label.toLowerCase(),
+					"count": origHash[i][1].count,
 					"sum": origHash[i][1].sum}
 				);
 			}
@@ -1817,7 +1817,7 @@ var TooltipRender = require('./render.js');
 				}
 				link_lines[0][i].style.fill = this._getExpandStyling(link_lines[0][i].id);
 			}
-			
+
 			link_lines.style("font-weight", "normal");
 			link_lines.style("text-anchor", "end");
 
@@ -1961,8 +1961,8 @@ var TooltipRender = require('./render.js');
 		_selectXItem: function(data, obj) {
 			// HACK: this temporarily 'disables' the mouseover when the stickytooltip is docked
 			// that way the user doesn't accidently hover another label which caused tooltip to be refreshed
-			if (stickytooltip.isdocked) { 
-				return; 
+			if (stickytooltip.isdocked) {
+				return;
 			}
 
 			var self = this;
@@ -1982,7 +1982,7 @@ var TooltipRender = require('./render.js');
 			// create the related model rectangles
 			var highlight_rect = self.state.svg.append("svg:rect")
 				.attr("transform","translate(" + (self.state.textWidth + self.state.xOffsetOver + 34.5) + "," + self.state.yoffsetOver + ")")
-				.attr("x", function(d) { 
+				.attr("x", function(d) {
 					return (self.state.xScale(data) - 1);
 				})
 				.attr("y", self.state.yoffset + 3)
@@ -2010,8 +2010,8 @@ var TooltipRender = require('./render.js');
 		_selectYItem: function(curr_data, obj) {
 			var appearanceOverrides;
 			// create a highlight row
-			if (stickytooltip.isdocked) { 
-				return; 
+			if (stickytooltip.isdocked) {
+				return;
 			}
 
 			var self = this;
@@ -2062,10 +2062,10 @@ var TooltipRender = require('./render.js');
 			return appearanceOverrides;
 		},
 
-		
-		
+
+
 		// Why not prefixed with underscore? - Joe
-		
+
 		// This builds the string to show the relations of the HPO nodes.  It recursively cycles through the edges and in the end returns the full visual structure displayed in the phenotype hover
 		buildHPOTree: function(id, edges, level) {
 			var results = "";
@@ -2082,7 +2082,7 @@ var TooltipRender = require('./render.js');
 						if (this.state.hpoTreeHeight < nextLevel){
 							this.state.hpoTreeHeight++;
 						}
-						
+
 						nextResult = this.buildHPOTree(edges[j].obj, edges, nextLevel);
 						if (nextResult === '') {
 							// Bolds the 'top of the line' to see what is the root or closet to the root.  It will hit this point either when it reaches the hpoDepth or there is no parents
@@ -2112,7 +2112,7 @@ var TooltipRender = require('./render.js');
 			for (var i = 1; i < hpoTreeHeight; i++){
 				indent += "<em class='HPO_tree_indent'></em>";
 			}
-			 
+
 			return indent + '&#8627'; // HTML entity - Joe
 		},
 
@@ -2288,7 +2288,7 @@ var TooltipRender = require('./render.js');
 				.attr('y', y-10)
 				.attr('width', 9)
 				.attr('height', 9)
-				.attr('xlink:href', this.state.imagePath + '.checkmark-drk.png'); 
+				.attr('xlink:href', this.state.imagePath + '.checkmark-drk.png');
 			}
 
 			el.remove();
@@ -2306,13 +2306,13 @@ var TooltipRender = require('./render.js');
 			var hgt = displayCount * 10 + this.state.yoffset;
 			var yv, wv;
 
-			if (coords.y > hgt) { 
+			if (coords.y > hgt) {
 				yv = coords.y - this.state.detailRectHeight - 5;
 			} else {
 				yv = coords.y + 20;
 			}
 
-			if (coords.x > wdt) { 
+			if (coords.x > wdt) {
 				wv = coords.x - w - 10;
 			} else {
 				wv = coords.x + 20;
@@ -2327,7 +2327,7 @@ var TooltipRender = require('./render.js');
 				.attr("x", wv)
 				.append("xhtml:div") // CSS needs to be applied to this div - Joe
 				.html(htmltext);
-				
+
 				//console.log($('#pg_detail_content').html()); //Debugging - Joe
 		},
 
@@ -2349,7 +2349,7 @@ var TooltipRender = require('./render.js');
 			} else {
 				phenoLabel = null;
 			}
-			
+
 			if (this.state.modelListHash.containsKey(d.xID)) {
 				modelLabel = this.state.modelListHash.get(d.xID).label;
 			} else if (this.state.modelListHash.containsKey(d.yID)) {
@@ -2395,7 +2395,7 @@ var TooltipRender = require('./render.js');
 				"<br/><strong>" + this._capitalizeString(fullInfo.type)+": </strong> " + modelLabel +
 				"<br/><strong>" + prefix + ":</strong> " + d.value[this.state.selectedCalculation].toFixed(2) + suffix +
 				"<br/><strong>Species: </strong> " + species + " (" + taxon + ")";
-			
+
 			this._updateDetailSection(retData, this._getXYPos(obj));
 		},
 
@@ -2439,12 +2439,13 @@ var TooltipRender = require('./render.js');
 				.data(data, function(d) {
 					return d.xID + d.yID;
 				});
-			
+
 			model_rects.enter()
 				.append("rect")
 				.attr("transform", rectTranslation) // moves the data cells to region - Joe
-				.attr("class", function(d) { // e.g. class="models  MGI_98331 MGI_98331HP_0000739" - Joe
-					var dConcept = (d.xID + ' ' + d.yID);
+				.attr("class", 'models')
+				.attr("id", function(d) { // e.g. id="cell_MGI_98331_HP_0000739" - Joe
+					var dConcept = (d.xID + '_' + d.yID);
 					var modelConcept = self._getConceptId(d.xID);
 					// append the model id to all related items
 					if (d.value[self.state.selectedCalculation] > 0) {
@@ -2452,12 +2453,12 @@ var TooltipRender = require('./render.js');
 						bla.classed(modelConcept, true);
 					}
 
-					return "models" + " " + dConcept;
+					return "cell_" + dConcept;
 				})
 				.attr("y", function(d, i) {
 					return self._getAxisData(d.yID).ypos + self.state.yoffsetOver;
 				})
-				.attr("x", function(d) { 
+				.attr("x", function(d) {
 					return self.state.xScale(d.xID);
 				})
 				.attr("width", 10) // size of each cube - Joe
@@ -2465,18 +2466,18 @@ var TooltipRender = require('./render.js');
 				// I need to pass this into the function
 				.on("mouseover", function(d) {
 					this.parentNode.appendChild(this);
-					
+
 					self._highlightIntersection(d, d3.mouse(this));
 					self._enableRowColumnRects(this);
 					self.state.currSelectedRect = this;
-					
+
 					self._showModelData(d, this);
 				})
 				.on("mouseout", function(d) {
 					// De-highlight row and column
 					self.state.svg.selectAll(".pg_row_accent").remove();
 					self.state.svg.selectAll(".pg_col_accent").remove();
-					
+
 					// Reset model data tooltip content
 					self.state.svg.selectAll("#pg_detail_content").remove();
 
@@ -2509,7 +2510,7 @@ var TooltipRender = require('./render.js');
 				.attr("x", function(d) {
 					return self.state.xScale(d.xID) + 2; // x position of the cubes region - Joe
 				});
-			
+
 			model_rects.exit().remove();
 		},
 
@@ -2564,8 +2565,8 @@ var TooltipRender = require('./render.js');
 					border_rect.attr("x", 0);
 					border_rect.attr("y", function(d, i) {
 						totCt += ct;
-						if (i === 0) { 
-							return (self.state.yoffset + borderStroke); 
+						if (i === 0) {
+							return (self.state.yoffset + borderStroke);
 						} else {
 							parCt = totCt - ct;
 							return (self.state.yoffset + borderStroke) + ((vwidthAndGap) * parCt + i);
@@ -2574,28 +2575,28 @@ var TooltipRender = require('./render.js');
 				} else if (self.state.targetSpeciesName == 'Overview' && ! this.state.invertAxis) {
 					border_rect.attr("x", function(d, i) {
 						totCt += ct;
-						if (i === 0) { 
-							return 0; 
-						} else if (i === 1) { 
-							return width - 2; 
-						} else if (i === 2) { 
+						if (i === 0) {
+							return 0;
+						} else if (i === 1) {
+							return width - 2;
+						} else if (i === 2) {
 							return width *2 - 4; // Magic numbers to move the position - Joe
 						}
-						
+
 						else {
 							parCt = totCt - ct;
 							return hwidthAndGap * parCt;
 						}
 					})
 					.attr("width", hwidthAndGap * ct + 1); // magic number 1 makes the width a little wider - Joe
-					
+
 					border_rect.attr("y", self.state.yoffset + 1);
 				} else {
 					border_rect.attr("x", function(d, i) {
 						totCt += ct;
-						if (i === 0) { 
-							return 0; 
-						} 
+						if (i === 0) {
+							return 0;
+						}
 						else {
 							parCt = totCt - ct;
 							return hwidthAndGap * parCt;
@@ -2609,7 +2610,7 @@ var TooltipRender = require('./render.js');
 			var self = this;
 
 			var model_rects = self.state.svg.selectAll("rect.models")
-				.filter(function(d) { 
+				.filter(function(d) {
 					return d.rowid == curr_rect.__data__.rowid;
 				});
 			for (var i in model_rects[0]){
@@ -2619,7 +2620,7 @@ var TooltipRender = require('./render.js');
 				model_rects[0][i].parentNode.appendChild(model_rects[0][i]);
 			}
 			var data_rects = self.state.svg.selectAll("rect.models")
-				.filter(function(d) { 
+				.filter(function(d) {
 					return d.model_id == curr_rect.__data__.model_id;
 				});
 			for (var j in data_rects[0]){
@@ -2638,7 +2639,7 @@ var TooltipRender = require('./render.js');
 				.attr("transform", "translate(" + (self.state.axis_pos_list[1] + 2) + ","+ (self.state.yoffsetOver + 6 ) + ")") // position control -Joe
 				.attr("x", 12)
 				.attr("y", function(d) {
-					return self._getAxisData(curr_data.yID).ypos; 
+					return self._getAxisData(curr_data.yID).ypos;
 				}) //rowid
 				.attr("class", "pg_row_accent")
 				.attr("width", this.state.modelWidth - 4)
@@ -2664,7 +2665,7 @@ var TooltipRender = require('./render.js');
 			// create the related model rectangles
 			var highlight_rect2 = self.state.svg.append("svg:rect")
 				.attr("transform", "translate(" + (self.state.textWidth + self.state.xOffsetOver + 36) + "," + (self.state.yoffsetOver + 1) +  ")") // position control -Joe
-				.attr("x", function(d) { 
+				.attr("x", function(d) {
 					return (self.state.xScale(curr_data.xID) - 1);
 				})
 				.attr("y", self.state.yoffset + 2 )
@@ -2686,8 +2687,8 @@ var TooltipRender = require('./render.js');
 			this.state.h = (data.length * 2.5);
 
 			self.state.yScale = d3.scale.ordinal()
-				.domain(data.map(function(d) { 
-					return d.yID; 
+				.domain(data.map(function(d) {
+					return d.yID;
 				}))
 				.range([0,data.length])
 				.rangePoints([self.state.yModelRegion,self.state.yModelRegion + this.state.h]);
@@ -2749,7 +2750,7 @@ var TooltipRender = require('./render.js');
 
 		// Previously _clearModelLabels
 		_clearXLabels: function() {
-			// In SVG, the g element is a container used to group objects. Transformations applied to the g element are performed on all of its child elements. 
+			// In SVG, the g element is a container used to group objects. Transformations applied to the g element are performed on all of its child elements.
 			// Attributes applied are inherited by child elements. - Joe
 			this.state.svg.selectAll("g.x").remove(); // Fixed x labels overlaping - Joe
 			this.state.svg.selectAll("g .tick.major").remove(); // Can be removed? - Joe
@@ -2771,8 +2772,8 @@ var TooltipRender = require('./render.js');
 					.attr("y2", 0)
 					.attr("stroke", "#0F473E")
 					.attr("stroke-width", 1);
-			} 
-			
+			}
+
 			// Why the following? - Joe
 			this.state.svg.selectAll("path.domain").remove();
 			this.state.svg.selectAll("text.scores").remove();
@@ -2873,7 +2874,7 @@ var TooltipRender = require('./render.js');
 				.enter()
 				.append("text")
 				.attr("transform", translation)
-				.attr("x", function(d,i) { 
+				.attr("x", function(d,i) {
 					return (i + 1 / 2 ) * xPerModel;
 				})
 				.attr("id", "pg_specieslist")
@@ -2922,12 +2923,12 @@ var TooltipRender = require('./render.js');
 					draggable: true,
 					dialogClass: "faqdialog_bg_color",
 					position: {
-						my: "top", 
+						my: "top",
 						at: "top+25%",
 						of: "#pg_svg_area"
 					},
 					title: 'Phenogrid Notes',
-					
+
 					// Replace default jquery-ui titlebar close icon with font awesome - Joe
 					open: function(event, ui) {
 						// remove default close icon
@@ -2960,13 +2961,13 @@ var TooltipRender = require('./render.js');
 			var y = self.state.yModelRegion;
 			// create accent boxes
 			var rect_accents = this.state.svg.selectAll("#rect.accent")
-				.data([0,1,2], function(d) { 
+				.data([0,1,2], function(d) {
 					return d;
 				});
 			rect_accents.enter()
 				.append("rect")
 				.attr("class", "accent")
-				.attr("x", function(d, i) { 
+				.attr("x", function(d, i) {
 				    return self.state.axis_pos_list[i];
 				})
 				.attr("y", y)
@@ -3023,7 +3024,7 @@ var TooltipRender = require('./render.js');
 
 			this.state.xScale = d3.scale.ordinal()
 				.domain(mods.map(function (d) {
-					return d; 
+					return d;
 				}))
 				.rangeRoundBands([0,this.state.modelWidth]);
 
@@ -3059,7 +3060,7 @@ var TooltipRender = require('./render.js');
 		_addGradients: function() {
 			var self = this;
 			var modData = this.state.modelDataHash.values();
-			var temp_data = modData.map(function(d) { 
+			var temp_data = modData.map(function(d) {
 				return d.value[self.state.selectedCalculation];
 			});
 			var diff = d3.max(temp_data) - d3.min(temp_data);
@@ -3084,7 +3085,7 @@ var TooltipRender = require('./render.js');
 			var y;
 			// If this is the Overview, get gradients for all species with an index
 			// COMPARE CALL HACK - REFACTOR OUT
-			if ((this.state.targetSpeciesName == 'Overview' || this.state.targetSpeciesName == 'All') 
+			if ((this.state.targetSpeciesName == 'Overview' || this.state.targetSpeciesName == 'All')
 				|| (this.state.targetSpeciesName == "Homo sapiens" && (this.state.owlSimFunction == "compare" || this.state.owlSimFunction == "exomiser"))) {
 				//this.state.overviewCount tells us how many fit in the overview
 				for (var i = 0; i < this.state.overviewCount; i++) {
@@ -3122,7 +3123,7 @@ var TooltipRender = require('./render.js');
 				.attr("x2", "100%")
 				.attr("y1", "0%")
 				.attr("y2", "0%");
-			
+
 			for (var j in this.state.colorDomains) {
 				if ( ! this.state.colorDomains.hasOwnProperty(j)) {
 					break;
@@ -3130,7 +3131,7 @@ var TooltipRender = require('./render.js');
 				gradient.append("svg:stop")
 					.attr("offset", this.state.colorDomains[j])
 					.style("stop-color", this.state.colorRanges[i][j])
-					.style("stop-opacity", 1); 
+					.style("stop-opacity", 1);
 			}
 
 			// gradient + gap is 20 pixels
@@ -3274,9 +3275,9 @@ var TooltipRender = require('./render.js');
 				"\" " + selectedItem + ">" + this.state.targetSpeciesList[idx].name + "</option>";
 			}
 			// add one for overview.
-			
+
 			// Overview is not a proper name, change it later - Joe
-			
+
 			if (this.state.targetSpeciesName === 'Overview') {
 				selectedItem = 'selected';
 			} else {
@@ -3347,10 +3348,10 @@ var TooltipRender = require('./render.js');
 			list = self._getSortedIDListStrict(self.state.filteredYAxis.entries());
 
 			// Updating nodes - Joe
-			var rect_text = this.state.svg.selectAll(".a_text").data(list, function(d) { 
-					return d; 
+			var rect_text = this.state.svg.selectAll(".a_text").data(list, function(d) {
+					return d;
 				});
-			
+
 			// Enter, create new nodes for incoming data - Joe
 			rect_text.enter()
 				.append("text")
@@ -3373,7 +3374,7 @@ var TooltipRender = require('./render.js');
 				.on("mouseover", function(d) {
 					self._selectYItem(d, d3.mouse(this));
 				})
-				.on("mouseout", function(d) { 
+				.on("mouseout", function(d) {
 					self._deselectData(d, d3.mouse(this));
 				})
 				.attr("data-tooltip", "sticky1")
@@ -3410,7 +3411,7 @@ var TooltipRender = require('./render.js');
 			var tempObject = {"id": 0, "observed": "positive"};
 
 			for (var i in fullset) {
-				if ( ! fullset.hasOwnProperty(i)) { 
+				if ( ! fullset.hasOwnProperty(i)) {
 					break;
 				}
 				if (typeof(fullset[i].id) === 'undefined') {
@@ -3586,8 +3587,8 @@ var TooltipRender = require('./render.js');
 				hpoData += "<strong>IC:</strong> " + info.IC.toFixed(2) + "<br/><br/>";
 
 				var hpoTree = this.buildHPOTree(id.replace("_", ":"), hpoCached.edges, 0);
-				
-	
+
+
 				if (hpoTree == "<br/>") {
 					hpoData += "<em>No HPO Data Found</em>";
 				} else {
@@ -3600,7 +3601,7 @@ var TooltipRender = require('./render.js');
 			}
 		},
 
-		// Will hide the hpo info, not delete it.  
+		// Will hide the hpo info, not delete it.
 		// This allows for reloading to be done faster and avoid unneeded server calls.  Not available if preloading
 		_collapseHPO: function(id) {
 			var idClean = id.replace("_", ":");
@@ -3610,8 +3611,8 @@ var TooltipRender = require('./render.js');
 			stickytooltip.closetooltip();
 		},
 
-		// When provided with an ID, it will first check hpoCacheHash if currently has the HPO data stored, 
-		// and if it does it will set it to be visible.  If it does not have that information in the hpoCacheHash, 
+		// When provided with an ID, it will first check hpoCacheHash if currently has the HPO data stored,
+		// and if it does it will set it to be visible.  If it does not have that information in the hpoCacheHash,
 		// it will make a server call to get the information and if successful will parse the information into hpoCacheHash and hpoCacheLabels
 		_getHPO: function(id) {
 			// check cached hashtable first
@@ -3636,11 +3637,11 @@ var TooltipRender = require('./render.js');
 						if ( ! nodes.hasOwnProperty(i)) {
 							break;
 						}
-						if ( ! this.state.hpoCacheLabels.containsKey(nodes[i].id) 
-							&& (nodes[i].id != "MP:0000001" 
-							&& nodes[i].id != "OBO:UPHENO_0001001" 
-							&& nodes[i].id != "OBO:UPHENO_0001002" 
-							&& nodes[i].id != "HP:0000118" 
+						if ( ! this.state.hpoCacheLabels.containsKey(nodes[i].id)
+							&& (nodes[i].id != "MP:0000001"
+							&& nodes[i].id != "OBO:UPHENO_0001001"
+							&& nodes[i].id != "OBO:UPHENO_0001002"
+							&& nodes[i].id != "HP:0000118"
 							&& nodes[i].id != "HP:0000001")) {
 							this.state.hpoCacheLabels.put(nodes[i].id, this._capitalizeString(nodes[i].lbl));
 						}
@@ -3651,10 +3652,10 @@ var TooltipRender = require('./render.js');
 						if ( ! edges.hasOwnProperty(j)) {
 							break;
 						}
-						if (edges[j].obj != "MP:0000001" 
-							&& edges[j].obj != "OBO:UPHENO_0001001" 
-							&& edges[j].obj != "OBO:UPHENO_0001002" 
-							&& edges[j].obj != "HP:0000118" 
+						if (edges[j].obj != "MP:0000001"
+							&& edges[j].obj != "OBO:UPHENO_0001001"
+							&& edges[j].obj != "OBO:UPHENO_0001002"
+							&& edges[j].obj != "HP:0000118"
 							&& edges[j].obj != "HP:0000001") {
 							HPOInfo.push(edges[j]);
 						}
@@ -3986,7 +3987,7 @@ var TooltipRender = require('./render.js');
 		_rebuildModelHash: function() {
 			// [vaa12] needs updating based on changes in finishLoad and finishOverviewLoad
 			this.state.phenotypeListHash = new Hashtable();
-			
+
 			// Create a new empty hash table with supplied options, Hashtable(Object options) - Joe
 			this.state.modelDataHash = new Hashtable({hashCode: model.modelDataPointPrint, equals: model.modelDataPointEquals});
 			var modelPoint, hashData;
@@ -4016,7 +4017,7 @@ var TooltipRender = require('./render.js');
 			}
 		},
 
-		
+
 		// According to harry, not showing in current master version - Joe
 		_getAssociatedGenotypes: function(curModel) {
 			// check cached hashtable first

--- a/index.html
+++ b/index.html
@@ -3,17 +3,12 @@
 <meta charset="UTF-8">
 <title>Monarch Phenotype Grid Widget</title>
 
-<script src="config/phenogrid_config.js"></script>
-<script src="dist/phenogrid-bundle.js"></script>
-
-<link rel="stylesheet" type="text/css" href="dist/phenogrid-bundle.css">
-
+<!--
 <style type="text/css">
 /* ==========================================================================
    Print styles.
    Inlined to avoid required HTTP connection: h5bp.com/r
    ========================================================================== */
-
 @media print {
     * {
         background: transparent !important;
@@ -26,7 +21,7 @@
     a:visited {
         text-decoration: underline;
     }
-    
+
     /* Disabled by PotatoGuide
     a[href]:after {
         content: " (" attr(href) ")";
@@ -36,7 +31,7 @@
         content: " (" attr(title) ")";
     }
     */
-    
+
     /*
      * Don't show links for images, or javascript/internal links
      */
@@ -76,14 +71,14 @@
     h3 {
         page-break-after: avoid;
     }
-    
+
     /* PotatoGuide */
     .print_hide {
-        display: none !important; 
+        display: none !important;
     }
 
     .print_show {
-        display: inherit !important; 
+        display: inherit !important;
     }
 
 }
@@ -145,7 +140,7 @@ margin:20px 0;
 
 .table th {
 line-height:1.6;
-padding:15px 10px; 
+padding:15px 10px;
 background:#f8f8f8;;
 border:1px solid #ddd;
 /* The text in th are bold and centered by default. */
@@ -153,7 +148,7 @@ border:1px solid #ddd;
 
 .table td {
 line-height:1.6;
-padding:10px; 
+padding:10px;
 border:1px solid #ccc;
 }
 
@@ -165,9 +160,9 @@ background-color:#fefbd6;
 /*--------------------------------------------------------------
 syntac highlighter
 -------------------------------------------------------------- */
-.syntax  { 
+.syntax  {
 font-size: 14px;
-background: #f8f8f8; 
+background: #f8f8f8;
 border:1px solid #ddd;
 padding:15px 20px;
 margin:10px 0;
@@ -182,7 +177,7 @@ right:0;
 top:0;
 border-left:1px solid #ddd;
 border-bottom:1px solid #ddd;
-background:#fffecf; 
+background:#fffecf;
 padding:5px 10px;
 text-align:center;
 font-size:.8em;
@@ -248,7 +243,15 @@ font-size:.8em;
 .syntax .vg { color: #19177C } /* Name.Variable.Global */
 .syntax .vi { color: #19177C } /* Name.Variable.Instance */
 .syntax .il { color: #666666 } /* Literal.Number.Integer.Long */
+
+
 </style>
+-->
+
+<script src="config/phenogrid_config.js"></script>
+<script src="dist/phenogrid-bundle.js"></script>
+
+<link rel="stylesheet" type="text/css" href="dist/phenogrid-bundle.css">
 
 <script>
 var phenotypes = [
@@ -267,7 +270,7 @@ var phenotypes = [
     {id:"HP:0002172", observed:"positive"},
     {id:"HP:0002322", observed:"positive"},
     {id:"HP:0007159", observed:"positive"}
-];  
+];
 
 window.onload = function() {
     Phenogrid.createPhenogridForElement(document.getElementById('phenogrid_container'), {
@@ -286,205 +289,104 @@ window.onload = function() {
 
 <div id="phenogrid_container" class="clearfix"></div>
 
-
-<h1>About Phenogrid</h1>
-
-<p>
-Phenogrid is implemented as a jQuery UI widget. The phenogrid widget uses semantic similarity calculations provided by OWLSim (www.owlsim.org), as provided through APIs from the Monarch Initiative (www.monarchinitiative.org).
-</p>
-
-<p>
-Given an input list of phenotypes (you will see the sample input below) and parameters specified in <code>config/phenogrid_config.js</code> indicating desired source of matching models (humans, model organisms, etc.), the phenogrid will call the Monarch API to get OWLSim results and render them in your web browser in data visualization. And you may use the visualized data for your research.
-</p>
-
-<h1>Installation Instructions</h1>
-
-<p>
-If you won't be doing any development of Phenogrid, you can simply download the phenogrid github zip file and unzip, then open the <code>index.html</code> to run this widget. 
-</p>
-
-<p>
-For developers who want to make changes to phenogrid, following is the process.
-</p>
-
-<h2>1. Make sure npm installed</h2>
-
-<p>
-Before you get started, you will need to make sure you have npm installed first. npm is bundled and installed automatically with node.js. If not, you need to install them.
-</p>
-
-<div class="syntax">
-<pre>
-curl -sL https://rpm.nodesource.com/setup <span class="p">|</span> bash -
+<link rel="stylesheet" type="text/css" href="node_modules/gfm.css/gfm.css">
+<div style="padding:1%;margin:1%;border:1px solid lightgray;">
+<article class="markdown-body">
+<h1 id="about-phenogrid">About Phenogrid</h1>
+<p>Phenogrid is a Javascript component that visualizes semantic similarity calculations provided by OWLSim (www.owlsim.org), as provided through APIs from the Monarch Initiative (www.monarchinitiative.org).</p>
+<p>Given an input list of phenotypes (you will see the sample input below) and parameters specified in config/phenogrid_config.js indicating desired source of matching models (humans, model organisms, etc.), the phenogrid will call the Monarch API to get OWLSim results and render them in your web browser in data visualization. And you may use the visualized data for your research.</p>
+<h1 id="installation-instructions">Installation Instructions</h1>
+<p>If you won’t be doing any development of Phenogrid, you can simply download the phenogrid github zip file and unzip, then open the <code>index.html</code> to run this widget.</p>
+<p>For developers who want to make changes to phenogrid, following is the process.</p>
+<h2 id="1-install-npm">1. Install npm</h2>
+<p>Before you get started, you will need to make sure you have npm<br>installed first. npm is bundled and installed automatically with<br>node.js. If you have not installed node.js, try:</p>
+<pre><code>curl -sL https://rpm.nodesource.com/setup | bash -
 
 yum install -y nodejs
-</pre>
-</div>
+</code></pre><p>For OS X machines, you can try these instructions:<br><a href="http://blog.teamtreehouse.com/install-node-js-npm-mac">http://blog.teamtreehouse.com/install-node-js-npm-mac</a>.</p>
+<p>Or, just visit nodejs.org.</p>
+<h2 id="2-install-phenogrid-widget">2. Install phenogrid widget</h2>
+<p>To download and install the phenogrid widget, run</p>
+<pre><code>npm install
+</code></pre><p>from this directory.<br>Sometimes, it requires root access to for the installation, just run the following instead</p>
+<pre><code>sudo npm install
+</code></pre><p>This will create a local <code>/node_modules</code> folder in the phenogrid root directory, and download/install all the dependencies(jquery, jquery-ui, d3, and jshashtable) and tools (gulp, browserify, etc.) into the local <code>/node_modules</code> folder.</p>
+<h2 id="3-run-gulp-to-build-bundled-js-and-css">3. Run gulp to build bundled JS and CSS</h2>
+<pre><code>gulp bundle
+</code></pre><p>This command will use browserify to bundle up phenogrid core and its<br>dependencies into <code>phenogrid-bundle.js</code> and create the merge<br><code>phenogrid-bundle.css</code> and put both files under <code>dist</code> folder.</p>
+<h2 id="4-add-phenogrid-in-your-target-page">4. Add phenogrid in your target page</h2>
+<p>In the below sample code, you will see how to use phenogrid as a<br>embeded widget in your HTML. Please note that in order to parse the js<br>file correctly (since it uses D3.js and D3.js requires UTF-8 charset<br>encoding), we suggest you to add the <code>&lt;meta charset=&quot;UTF-8&quot;&gt;</code> tag in<br>your HTML head.</p>
+<pre><code class="lang-html">&lt;html&gt;
+&lt;head&gt;
+&lt;meta charset=&quot;UTF-8&quot;&gt;
+&lt;title&gt;Monarch Phenotype Grid Widget&lt;/title&gt;
 
-<h2>2. Install phenogrid widget</h2>
+&lt;script src=&quot;config/phenogrid_config.js&quot;&gt;&lt;/script&gt;
+&lt;script src=&quot;dist/phenogrid-bundle.js&quot;&gt;&lt;/script&gt;
 
-<p>
-Now it's time to download and extract our phenogrid widget. In the phenogrid package directory, just run
-</p>
+&lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;dist/phenogrid-bundle.css&quot;&gt;
 
+&lt;script&gt;
+var phenotypes = [
+    {id:&quot;HP:0000726&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0000746&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0001300&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0002367&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0000012&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0000716&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0000726&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0000739&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0001332&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0001347&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0002063&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0002067&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0002172&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0002322&quot;, observed:&quot;positive&quot;},
+    {id:&quot;HP:0007159&quot;, observed:&quot;positive&quot;}
+];
 
-<div class="syntax">
-<pre>
-npm install
-</pre>
-</div>
+window.onload = function() {
+    Phenogrid.createPhenogridForElement(document.getElementById(&#39;phenogrid_container&#39;), {
+        serverURL : &quot;http://beta.monarchinitiative.org&quot;,
+        phenotypeData: phenotypes,
+        targetSpeciesName: &quot;Mus musculus&quot;
+    });
+}
+&lt;/script&gt;
 
-<p>
-Sometimes, it requires root access to for the installation, just run the following instead
-</p>
+&lt;/head&gt;
 
-<div class="syntax">
-<pre>
-sudo npm install
-</pre>
-</div>
+&lt;body&gt;
 
-<p>
-This will create a local <code>/node_modules</code> folder in the phenogrid root directory, and download/install all the dependencies(jquery, jquery-ui, d3, and jshashtable) and tools (gulp, browserify, etc.) into the local <code>/node_modules</code> folder.
-</p>
+&lt;div id=&quot;phenogrid_container&quot;&gt;&lt;/div&gt;
 
-<h2>3. Run gulp to build bundled JS and CSS</h2>
-
-<div class="syntax">
-<pre>
-gulp bundle
-</pre>
-</div>
-
-<p>
-This command will use browserify to bundle up phenogrid core and its dependencies into <code>phenogrid-bundle.js</code> and create the merge <code>phenogrid-bundle.css</code> and put both files under <code>/dist</code> folder.
-</p>
-
-<h2>4. Add phenogrid in your target page</h2>
-
-<p>
-In the below sample code, you will see how to use phenogrid as a embeded widget in your HTML. Please note that in order to parse the js file correctly (since it uses D3.js and D3.js requires UTF-8 charset encoding), we suggest you to add the <code>&lt;meta charset="UTF-8"&gt;</code> tag in your HTML head.
-</p>
-
-<div class="syntax"><pre><span class="nt">&lt;html&gt;</span>
-<span class="nt">&lt;head&gt;</span>
-<span class="nt">&lt;meta</span> <span class="na">charset=</span><span class="s">&quot;UTF-8&quot;</span><span class="nt">&gt;</span>
-<span class="nt">&lt;title&gt;</span>Monarch Phenotype Grid Widget<span class="nt">&lt;/title&gt;</span>
-
-<span class="nt">&lt;script </span><span class="na">src=</span><span class="s">&quot;config/phenogrid_config.js&quot;</span><span class="nt">&gt;&lt;/script&gt;</span>
-<span class="nt">&lt;script </span><span class="na">src=</span><span class="s">&quot;dist/phenogrid-bundle.js&quot;</span><span class="nt">&gt;&lt;/script&gt;</span>
-
-<span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">&quot;stylesheet&quot;</span> <span class="na">type=</span><span class="s">&quot;text/css&quot;</span> <span class="na">href=</span><span class="s">&quot;dist/phenogrid-bundle.css&quot;</span><span class="nt">&gt;</span>
-
-<span class="nt">&lt;script&gt;</span>
-<span class="kd">var</span> <span class="nx">phenotypes</span> <span class="o">=</span> <span class="p">[</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0000726&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0000746&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0001300&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0002367&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0000012&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0000716&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0000726&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0000739&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0001332&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0001347&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0002063&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0002067&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0002172&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0002322&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">},</span>
-	<span class="p">{</span><span class="nx">id</span><span class="o">:</span><span class="s2">&quot;HP:0007159&quot;</span><span class="p">,</span> <span class="nx">observed</span><span class="o">:</span><span class="s2">&quot;positive&quot;</span><span class="p">}</span>
-<span class="p">];</span>	
-
-<span class="nb">window</span><span class="p">.</span><span class="nx">onload</span> <span class="o">=</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
-    <span class="nx">Phenogrid</span><span class="p">.</span><span class="nx">createPhenogridForElement</span><span class="p">(</span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s1">&#39;phenogrid_container&#39;</span><span class="p">),</span> <span class="p">{</span>
-        <span class="nx">serverURL</span> <span class="o">:</span> <span class="s2">&quot;http://beta.monarchinitiative.org&quot;</span><span class="p">,</span>
-        <span class="nx">phenotypeData</span><span class="o">:</span> <span class="nx">phenotypes</span><span class="p">,</span>
-        <span class="nx">targetSpeciesName</span><span class="o">:</span> <span class="s2">&quot;Mus musculus&quot;</span>
-    <span class="p">});</span>
-<span class="p">}</span>
-<span class="nt">&lt;/script&gt;</span>
-
-<span class="nt">&lt;/head&gt;</span>
-
-<span class="nt">&lt;body&gt;</span>
-
-<span class="nt">&lt;div</span> <span class="na">id=</span><span class="s">&quot;phenogrid_container&quot;</span><span class="nt">&gt;&lt;/div&gt;</span>
-
-<span class="nt">&lt;/body&gt;</span>
-<span class="nt">&lt;/html&gt;</span>
-</pre></div>
-
-
-<h1>Configuration Parameters</h1>
-
-These variables can be changed either in the hash that is provided to
-the <em>createPhenogridForElement</em> call (for customization of the
-phenogrid on a specific page), or by modifiying
-the  <em>configOptions</em> hash in <em>conf/phenogrid_config.js</em>
-(for site-wide customization).  
-
-<table class="table"> 
-<thead>
-<tr><th>Parameter</th><th>Data Type</th><th>Required or Optional</th><th>Description</th></tr>
-</thead>
-
-<tbody>
-<tr> 
-<td><strong>serverURL</strong></td><td>string</td><td>required</td>
-<td>
-This URL should be pointed to the OWLSim URL server associated with your installation containing the Monarch web services. You have three options:
+&lt;/body&gt;
+&lt;/html&gt;
+</code></pre>
+<h1 id="configuration-parameters">Configuration Parameters</h1>
+<h2 id="-serverurl-string-required"><code>serverURL</code>  string | required</h2>
+<p>This URL should be pointed to the OWLSim URL server associated with your installation containing the Monarch web services. You have three options:</p>
 <ul>
-<li>Use http://beta.monarchinitiative.org to connect to the development/test web services. This server is less stable than the production server.</li>
-<li>Use http://monarch.monarchinitiative.org to connect to the stable, production version of the web services (better uptime)</li>
-<li>If you are running the complete monarch-app, you can point it to http://localhost:8080, or whichever server/port you are using in your local installation.</li>
+<li>Use <a href="http://beta.monarchinitiative.org">http://beta.monarchinitiative.org</a> to connect to the development/test web services. This server is less stable than the production server.</li>
+<li>Use <a href="http://monarch.monarchinitiative.org">http://monarch.monarchinitiative.org</a> to connect to the stable, production version of the web services (better uptime)</li>
+<li>If you are running the complete monarch-app, you can point it to <a href="http://localhost:8080">http://localhost:8080</a>, or whichever server/port you are using in your local installation.</li>
 </ul>
-</td> 
-</tr>
-
-<tr> 
-<td><strong>phenotypeData</strong></td><td>array</td><td>required</td>
-<td>
-<em>Required</em>:A Javascript array of objects listing the phenotypes to be rendered in the widget.
-</td> 
-</tr>
-
-<tr> 
-<td><strong>targetSpecies</strong></td><td>string</td><td>optional</td>
-<td>
-Change this parameter if you want to compare the phenotypes in the phenotypeData parameter against a different species. Available Species:
+<h2 id="-phenotypedata-array-required"><code>phenotypeData</code>  array | required</h2>
+<p>It is a Javascript array of objects listing the phenotypes to be rendered in the widget.</p>
+<h2 id="-targetspecies-string-optional"><code>targetSpecies</code>  string | optional</h2>
+<p>This parameter defaults to 10090 (mus musculus). Change this parameter if you want to compare the phenotypes in the phenotypeData parameter against a different species. Available Species:</p>
 <ul>
-<LI>Name: Mus musculus Taxon: 10090</li> <em>Default</em></li>
 <li>Name: Homo sapiens Taxon: 9606</li>
 <li>Name: Dani rerio Taxon: 7955</li>
 <li>Name: Drosophila melanogaster Taxon: 7227</li>
 </ul>
-</td> 
-</tr>
+<h1 id="testing-and-further-configuration">Testing and further configuration</h1>
+<p>Open the modified <code>index.html</code> or your target web page that has the phenogrid embeded in a web browser. This page will<br>display an instance of the phenogrid, as configured above. Additional<br>instructions for further customization of parameters will also be<br>available on this page.</p>
+<h1 id="web-browser-support">Web Browser Support</h1>
+<p>Some phenogrid features are not support by IE 11 and below. So please use Google chrome, Fireffox, or Safari to open this widget.</p>
 
-<tr> 
-<td><strong>simServerURL</strong></td><td>string</td><td>optional</td>
-<td>
-The URL of the server running the similarity comparison. Usually default to being the same as serverURL. Use the default (do not specify a value) unless you have an expliciit reason for doing otherwise.
-</td> 
-</tr>
-
-<tr> 
-</tbody>
-</table> 
-
-<h1>Testing and further configuration</h1>
-
-<p>
-Open the modified <code>index.html</code> or your target web page that has the phenogrid embeded in a web browser. This page will display an instance of the phenogrid, as configured above. Additional instructions for further customization of parameters will also be available on this page.
-</p>
-
-<h1>Web Browser Support</h1>
-
-<p>
-Some phenogrid features are not support by IE 11 and below. So please use Google chrome, Fireffox, or Safari to open this widget.	
-</p>
-
-</div>
+</article>
+<div/>
 
 </body>
 </html>

--- a/js/phenogrid.js
+++ b/js/phenogrid.js
@@ -1,9 +1,9 @@
 /*
  * Phenogrid
  *
- * Phenogrid is implemented as a jQuery UI widget. The phenogrid widget uses semantic similarity calculations provided 
+ * Phenogrid is implemented as a jQuery UI widget. The phenogrid widget uses semantic similarity calculations provided
  * by OWLSim (www.owlsim.org),  as provided through APIs from the Monarch Initiative (www.monarchinitiative.org).
- * 
+ *
  * Phenogrid widget can be instantiated on a jquery-enabled web page with a call of the form
  *
  * window.onload = function() {
@@ -13,7 +13,7 @@
  *         targetSpeciesName: "Mus musculus"
  *     });
  * }
- * 
+ *
  * 'phenogrid_container' is the id of the div that will contain the phenogrid widget
  *	phenotypes is a Javascript array of objects listing the phenotypes to be rendered in the widget, it takes one of two forms:
  *
@@ -52,7 +52,7 @@
 // Will need to install jquery, jquery-ui, d3, jshashtable first via npm - Joe
 // Note: jquery 2.1.0 is capable of using browserify's module.exports - Joe
 // npm install jquery jquery-ui d3 jshashtable
- 
+
 // NPM installed packages, you will find them in /node_modules - Joe
 
 // jquery  is commonsJS compliant as of 2.1.0 - Joe
@@ -79,7 +79,7 @@ var TooltipRender = require('./render.js');
 	} else {
 		factory($, window, document);
 	}
-})  
+})
 
 (function($, window, document, __undefined__) {
 	var createPhenogridForElement = function(element, options) {
@@ -90,7 +90,7 @@ var TooltipRender = require('./render.js');
 	window.Phenogrid = {
 		createPhenogridForElement: createPhenogridForElement
 	};
-	
+
 	// Use widget factory to define the UI plugin - Joe
 	// Can aslo be ns.phenogrid (ns can be anything else - namespace) - Joe
 	// Later can be called using $().phenogrid(); - Joe
@@ -98,9 +98,9 @@ var TooltipRender = require('./render.js');
 	$.widget("ui.phenogrid", {
 
 		// Why not prefixed with underscore? - Joe
-		
+
 		// core commit. Not changeable by options.
-		
+
 		// merged into this.state - Joe
 		// only used twice, one of them is for config.h, which according to the comments, h should be elimiated - Joe
 		// so we can just use one variable for all configs to contain everything in congig and internalOptions - Joe
@@ -141,7 +141,7 @@ var TooltipRender = require('./render.js');
 			comparisonTypes: [{organism: "Homo sapiens", comparison: "diseases"}],
 			defaultComparisonType: {comparison: "genes"},
 			// speciesLabels Not used - Joe
-			speciesLabels: [ 
+			speciesLabels: [
 				{abbrev: "HP", label: "Human"},
 				{abbrev: "MP", label: "Mouse"},
 				{abbrev: "ZFIN", label: "Zebrafish"},
@@ -152,7 +152,7 @@ var TooltipRender = require('./render.js');
 			],
 			dataDisplayCount: 30,
 			labelCharDisplayCount : 20,
-			apiEntityMap: [ 
+			apiEntityMap: [
 				{prefix: "HP", apifragment: "disease"},
 				{prefix: "OMIM", apifragment: "disease"}
 			],
@@ -173,7 +173,7 @@ var TooltipRender = require('./render.js');
 		},
 
 		// Why not prefixed with underscore? - Joe
-		
+
 		// merged into this.state - Joe
 		// only used once, so we can just use one variable to store all configs - Joe
 		internalOptions: {
@@ -196,7 +196,7 @@ var TooltipRender = require('./render.js');
 						{name: "Mus musculus", taxon: "10090" },
 						{name: "Danio rerio", taxon: "7955"},
 						{name: "Drosophila melanogaster", taxon: "7227"},
-						{name: "UDP", taxon: "UDP"} 
+						{name: "UDP", taxon: "UDP"}
 					],
 			// According to Harry, the genotype expand is not showing in current version - Joe
 			genotypeExpandLimit: 5, // sets the limit for the number of genotype expanded on grid
@@ -205,14 +205,14 @@ var TooltipRender = require('./render.js');
 			providedData: {}
 		},
 
-		
-		
-		
+
+
+
 		// Methods begin with underscore are not callable from outside of the plugin - Joe
-		
-		
-		
-		
+
+
+
+
 		// reset state values that must be cleared before reloading data
 		_reset: function(type) {
 			// LEAVE UNTIL OR MOVING HASH CONSTRUCTION EARLIER
@@ -319,14 +319,14 @@ var TooltipRender = require('./render.js');
 			return species;
 		},
 
-		
-		
-		
+
+
+
 		// _create() method is the widget's constructor, it is called for each element that the plugin method is called on - Joe
-		
-		
-		
-		
+
+
+
+
 		// NOTE: I'm not too sure what the default init() method signature should be given an imageDiv and phenotype_data list
 		/*
 		 * imageDiv - the place you want the widget to appear
@@ -336,35 +336,35 @@ var TooltipRender = require('./render.js');
 		 * [ "HP:12345", "HP:23451", ...]
 		 */
 		_create: function() {
-			
-			
-			
-			
-			
-			
-			
+
+
+
+
+
+
+
 			// local model.js into local scope - Joe
-			//this.model = model; 
-			
-			
-			
-			
-			
-			
-			
-			
-			
+			//this.model = model;
+
+
+
+
+
+
+
+
+
 			// must be available from js loaded in a separate file...
 			// configoptions is defined in phenogrid_config.js - Joe
-			
+
 			/* Content of phenogrid_config.js, just a copy for quick reference - Joe
-			
+
 			var configoptions = {
 				"serverURL": "",
 				"selectedCalculation": "0",
 				"invertAxis": false,
 				"selectedSort": "Frequency",
-				"targetSpeciesName" : "Overview",			   
+				"targetSpeciesName" : "Overview",
 				"refSpecies": "Homo sapiens",
 				"targetSpeciesList" : [
 					{ "name": "Homo sapiens", "taxon": "9606"},
@@ -376,30 +376,30 @@ var TooltipRender = require('./render.js');
 			*/
 
 			// loaded into local scope, should just remove the phenogrid_config.js and have those config options coded in this file. - Joe
-			this.configoptions = configoptions; 
+			this.configoptions = configoptions;
 			// check these
 			// important that config options (from the file) and this. options (from
 			// the initializer) come last
-			
+
 			// jquery $.extend(): Merge the contents of two or more objects together into the first object - Joe
 			// so now this.state contains all the config options - Joe
 			this.state = $.extend({}, this.internalOptions, this.config, this.configoptions, this.options);
-			
+
 			// Added by Joe - Joe
 			// simsearch returned data b[] is stored in this.state['data'] - Joe
-			console.log(this.state); 
-			
-			
+			console.log(this.state);
+
+
 			// Do we need this? - Joe
-			
+
 			// default simServerURL value..
 			if (typeof(this.state.simServerURL) == 'undefined' || this.state.simServerURL === '') {
 				this.state.simServerURL=this.state.serverURL;
 			}
-			
+
 			// contains all simsearch returned data - Joe
 			this.state.data = {};
-			
+
 			// will this work?
 			this.configoptions = undefined; // Did you want to reset this variable? Why only reset configoptions? - Joe
 
@@ -433,7 +433,7 @@ var TooltipRender = require('./render.js');
 		 * thus, a workaround is included below to set the path correctly if it come up as '/'.
 		 * this should not impact any standalone uses of phenogrid, and will be removed once monarch-app is cleaned up.
 		 */
-		 
+
 		/*
 		 * HACK WARNING - 20150713, dan@quantumclay.com
 		 * 	The serverURL corresponds to a running Monarch server that can provide 'help text'
@@ -447,7 +447,7 @@ var TooltipRender = require('./render.js');
 		 *	Currently, the existence of an explicit serverUrl (non-blank) is used to indicate that the
 		 *	workaround is necessary.
 		 */
-		 
+
 		 /*
 		 * HACK WARNING - 20150715, zhy19@pitt.edu
 		 * 	Added htmlPath to refer to the relative path to those FAQ html pages
@@ -459,12 +459,12 @@ var TooltipRender = require('./render.js');
 			return this.state.htmlPath + name + '.' + type;
 		},
 
-		
-		
+
+
 		// initialization, distinct from creation - Joe
-		
-		
-		
+
+
+
 		//init is now reduced down completely to loading
 		_init: function() {
 			this.element.empty();
@@ -494,7 +494,7 @@ var TooltipRender = require('./render.js');
 				this.state.stickyInitialized = true;
 				stickytooltip.init("*[data-tooltip]", "mystickytooltip");
 			}
-			
+
 			this.state.tooltipRender = new TooltipRender(this.state.serverURL);
 
 			if (this.state.owlSimFunction == 'exomiser') {
@@ -598,11 +598,11 @@ var TooltipRender = require('./render.js');
 			}
 		},
 
-		
-		
+
+
 		// https://api.jqueryui.com/jquery.widget/#method-_setOption - Joe
-		
-		
+
+
 		/* dummy option procedures as per
 		 * http://learn.jquery.com/jquery-ui/widget-factory/how-to-use-the-widget-factory/
 		 * likely to have some content added as we proceed
@@ -639,10 +639,10 @@ var TooltipRender = require('./render.js');
 				.append("rect")
 				.attr("id", "pg_gridline")
 				.attr("transform", "translate(254, " + (this.state.yModelRegion + 5) + ")") // position the pg_gridline net to region - Joe
-				.attr("x", function(d, i) { 
+				.attr("x", function(d, i) {
 					return d[1] * mWidth;
 				})
-				.attr("y", function(d, i) { 
+				.attr("y", function(d, i) {
 					return d[0] * mHeight;
 				})
 				.attr("class", "hour bordered deselected")
@@ -715,10 +715,10 @@ var TooltipRender = require('./render.js');
 				.append("rect")
 				.attr("transform", modelRectTransform)
 				.attr("class", "mini_model")
-				.attr("y", function(d, i) { 
+				.attr("y", function(d, i) {
 					return self.state.smallYScale(d.yID) + linePad / 2;
 				})
-				.attr("x", function(d) { 
+				.attr("x", function(d) {
 					return self.state.smallXScale(d.xID) + linePad / 2;
 				})
 				.attr("width", linePad)
@@ -761,7 +761,7 @@ var TooltipRender = require('./render.js');
 						var curY = parseFloat(current.attr("y"));
 
 						var rect = self.state.svg.select("#pg_selectionrect");
-						
+
 						rect.attr("transform", "translate(0, 0)"); // May not need this - Joe
 
 						// limit the range of the x value
@@ -864,7 +864,7 @@ var TooltipRender = require('./render.js');
 				var tipTextLength = 92;
 				var explYOffset = 15;
 				var explXOffset = 10;
-				
+
 				var scoretip = self.state.svg.append("text")
 					.attr("transform", "translate(" + (self.state.axis_pos_list[2] ) + "," + scoreTipY + ")")
 					.attr("x", 0)
@@ -875,7 +875,7 @@ var TooltipRender = require('./render.js');
 				var tip	= self.state.svg
 					.append("text")
 					.attr('font-family', 'FontAwesome')
-					.text(function(d) { 
+					.text(function(d) {
 						return '\uF05A\n'; // Need to convert HTML/CSS unicode to javascript unicode - Joe
 					})
 					.attr("id", "modelscores")
@@ -893,7 +893,7 @@ var TooltipRender = require('./render.js');
 					.attr("class", "pg_tip")
 					.text("Best matches high to low"); // uppercased best - > Best - Joe
 			}
-			
+
 		},
 
 		// Overview navigation - Joe
@@ -912,7 +912,7 @@ var TooltipRender = require('./render.js');
 
 			// There's better way to create this two-line text - Joe
 			// SVG 1.2 supports textarea, not all browsers support it though - Joe
-			
+
 			var y = self.state.yModelRegion + overviewBoxDim + overviewInstructionHeightOffset;
 			var rect_instructions = self.state.svg.append("text")
 				.attr("x", self.state.axis_pos_list[2] + 10)
@@ -939,12 +939,12 @@ var TooltipRender = require('./render.js');
 
 			this.state.smallYScale = d3.scale.ordinal()
 				.domain(sortDataList.map(function (d) {
-					return d; 
+					return d;
 				}))
 				.rangePoints([0,overviewRegionSize]);
 
 			var modids = mods.map(function (d) {
-				return d; 
+				return d;
 			});
 			this.state.smallXScale = d3.scale.ordinal()
 				.domain(modids)
@@ -1117,12 +1117,12 @@ var TooltipRender = require('./render.js');
 			this.state.phenotypeListHash = new Hashtable();
 			this.state.modelListHash = new Hashtable();
 			// Create a new empty hash table with supplied options, Hashtable(Object options) - Joe
-			// hashCode: A function that provides hash codes for keys placed in the hash table. 
-			// equals: A function that checks for equality between two keys with the same hash code. 
+			// hashCode: A function that provides hash codes for keys placed in the hash table.
+			// equals: A function that checks for equality between two keys with the same hash code.
 			//this.state.modelDataHash = new Hashtable({hashCode: this.model.modelDataPointPrint, equals: this.model.modelDataPointEquals});
 			this.state.modelDataHash = new Hashtable({hashCode: model.modelDataPointPrint, equals: model.modelDataPointEquals});
 
-			
+
 			// [vaa12] determine if is wise to preload datasets for the three species and then build overview from this
 			// At time being, overview is made up of three calls, which it repeats these calls with a larger limit if you decided to view single species
 			// Might be more efficent to load those three, cache them and then make an overview dataset and cache that as well.
@@ -1190,7 +1190,7 @@ var TooltipRender = require('./render.js');
 			var toadd = limit - res.b.length;
 			for (var i = 0; i < toadd; i++) {
 				var dummyId = "dummy" + species + i;
-				var newItem = { 
+				var newItem = {
 					id: dummyId,
 					label: this.state.dummyModelName,
 					score: {score: 0, rank: Number.MAX_VALUE},
@@ -1260,12 +1260,12 @@ var TooltipRender = require('./render.js');
 						}
 
 						hashData = {
-							"label": item.label, 
-							"species": species, 
-							"taxon": item.taxon.id, 
-							"type": type, 
-							"pos": parseInt(posID), 
-							"rank": parseInt(idx), 
+							"label": item.label,
+							"species": species,
+							"taxon": item.taxon.id,
+							"type": type,
+							"pos": parseInt(posID),
+							"rank": parseInt(idx),
 							"score": item.score.score
 						};
 						// use put(key, value) to add a key/value pair to the hashtable, and get() to retrieve a value - Joe
@@ -1364,20 +1364,20 @@ var TooltipRender = require('./render.js');
 						modelPoint = new model.modelDataPoint(this._getConceptId(modelID), this._getConceptId(curr_row.a.id));
 					}
 					this._updateSortVals(this._getConceptId(curr_row.a.id), parseFloat(curr_row.lcs.IC));
-					
+
 					// simsearch returns array b:[{}...] with all the matched results. Each item in array b is an object
 					// that contains: id, label, matches[], score{}, taxon{}, and type. - Joe
-					
+
 					hashData = {
-						"value": lcs, 
-						"subsumer_label": curr_row.lcs.label, 
-						"subsumer_id": this._getConceptId(curr_row.lcs.id), 
-						"subsumer_IC": parseFloat(curr_row.lcs.IC), 
-						"b_label": curr_row.b.label, 
-						"b_id": this._getConceptId(curr_row.b.id), 
+						"value": lcs,
+						"subsumer_label": curr_row.lcs.label,
+						"subsumer_id": this._getConceptId(curr_row.lcs.id),
+						"subsumer_IC": parseFloat(curr_row.lcs.IC),
+						"b_label": curr_row.b.label,
+						"b_id": this._getConceptId(curr_row.b.id),
 						"b_IC": parseFloat(curr_row.b.IC)
 					};
-					
+
 					this.state.modelDataHash.put(modelPoint, hashData);
 				}
 			}
@@ -1450,8 +1450,8 @@ var TooltipRender = require('./render.js');
 				return this.state.yAxis.get(key);
 			} else if (this.state.xAxis.containsKey(key)) {
 				return this.state.xAxis.get(key);
-			} else { 
-				return false; 
+			} else {
+				return false;
 			}
 		},
 
@@ -1461,8 +1461,8 @@ var TooltipRender = require('./render.js');
 				return 'Model';
 			} else if (this.state.phenotypeListHash.containsKey(key)) {
 				return 'Phenotype';
-			} else { 
-				return false; 
+			} else {
+				return false;
 			}
 		},
 
@@ -1518,9 +1518,9 @@ var TooltipRender = require('./render.js');
 			for (var i in origHash){
 				if(!origHash.hasOwnProperty(i)){break;}
 				newHash.push({
-					"id": origHash[i][0], 
-					"label": origHash[i][1].label.toLowerCase(), 
-					"count": origHash[i][1].count, 
+					"id": origHash[i][0],
+					"label": origHash[i][1].label.toLowerCase(),
+					"count": origHash[i][1].count,
 					"sum": origHash[i][1].sum}
 				);
 			}
@@ -1792,7 +1792,7 @@ var TooltipRender = require('./render.js');
 				}
 				link_lines[0][i].style.fill = this._getExpandStyling(link_lines[0][i].id);
 			}
-			
+
 			link_lines.style("font-weight", "normal");
 			link_lines.style("text-anchor", "end");
 
@@ -1936,8 +1936,8 @@ var TooltipRender = require('./render.js');
 		_selectXItem: function(data, obj) {
 			// HACK: this temporarily 'disables' the mouseover when the stickytooltip is docked
 			// that way the user doesn't accidently hover another label which caused tooltip to be refreshed
-			if (stickytooltip.isdocked) { 
-				return; 
+			if (stickytooltip.isdocked) {
+				return;
 			}
 
 			var self = this;
@@ -1957,7 +1957,7 @@ var TooltipRender = require('./render.js');
 			// create the related model rectangles
 			var highlight_rect = self.state.svg.append("svg:rect")
 				.attr("transform","translate(" + (self.state.textWidth + self.state.xOffsetOver + 34.5) + "," + self.state.yoffsetOver + ")")
-				.attr("x", function(d) { 
+				.attr("x", function(d) {
 					return (self.state.xScale(data) - 1);
 				})
 				.attr("y", self.state.yoffset + 3)
@@ -1985,8 +1985,8 @@ var TooltipRender = require('./render.js');
 		_selectYItem: function(curr_data, obj) {
 			var appearanceOverrides;
 			// create a highlight row
-			if (stickytooltip.isdocked) { 
-				return; 
+			if (stickytooltip.isdocked) {
+				return;
 			}
 
 			var self = this;
@@ -2037,10 +2037,10 @@ var TooltipRender = require('./render.js');
 			return appearanceOverrides;
 		},
 
-		
-		
+
+
 		// Why not prefixed with underscore? - Joe
-		
+
 		// This builds the string to show the relations of the HPO nodes.  It recursively cycles through the edges and in the end returns the full visual structure displayed in the phenotype hover
 		buildHPOTree: function(id, edges, level) {
 			var results = "";
@@ -2057,7 +2057,7 @@ var TooltipRender = require('./render.js');
 						if (this.state.hpoTreeHeight < nextLevel){
 							this.state.hpoTreeHeight++;
 						}
-						
+
 						nextResult = this.buildHPOTree(edges[j].obj, edges, nextLevel);
 						if (nextResult === '') {
 							// Bolds the 'top of the line' to see what is the root or closet to the root.  It will hit this point either when it reaches the hpoDepth or there is no parents
@@ -2087,7 +2087,7 @@ var TooltipRender = require('./render.js');
 			for (var i = 1; i < hpoTreeHeight; i++){
 				indent += "<em class='HPO_tree_indent'></em>";
 			}
-			 
+
 			return indent + '&#8627'; // HTML entity - Joe
 		},
 
@@ -2263,7 +2263,7 @@ var TooltipRender = require('./render.js');
 				.attr('y', y-10)
 				.attr('width', 9)
 				.attr('height', 9)
-				.attr('xlink:href', this.state.imagePath + '.checkmark-drk.png'); 
+				.attr('xlink:href', this.state.imagePath + '.checkmark-drk.png');
 			}
 
 			el.remove();
@@ -2281,13 +2281,13 @@ var TooltipRender = require('./render.js');
 			var hgt = displayCount * 10 + this.state.yoffset;
 			var yv, wv;
 
-			if (coords.y > hgt) { 
+			if (coords.y > hgt) {
 				yv = coords.y - this.state.detailRectHeight - 5;
 			} else {
 				yv = coords.y + 20;
 			}
 
-			if (coords.x > wdt) { 
+			if (coords.x > wdt) {
 				wv = coords.x - w - 10;
 			} else {
 				wv = coords.x + 20;
@@ -2302,7 +2302,7 @@ var TooltipRender = require('./render.js');
 				.attr("x", wv)
 				.append("xhtml:div") // CSS needs to be applied to this div - Joe
 				.html(htmltext);
-				
+
 				//console.log($('#pg_detail_content').html()); //Debugging - Joe
 		},
 
@@ -2324,7 +2324,7 @@ var TooltipRender = require('./render.js');
 			} else {
 				phenoLabel = null;
 			}
-			
+
 			if (this.state.modelListHash.containsKey(d.xID)) {
 				modelLabel = this.state.modelListHash.get(d.xID).label;
 			} else if (this.state.modelListHash.containsKey(d.yID)) {
@@ -2370,7 +2370,7 @@ var TooltipRender = require('./render.js');
 				"<br/><strong>" + this._capitalizeString(fullInfo.type)+": </strong> " + modelLabel +
 				"<br/><strong>" + prefix + ":</strong> " + d.value[this.state.selectedCalculation].toFixed(2) + suffix +
 				"<br/><strong>Species: </strong> " + species + " (" + taxon + ")";
-			
+
 			this._updateDetailSection(retData, this._getXYPos(obj));
 		},
 
@@ -2414,7 +2414,7 @@ var TooltipRender = require('./render.js');
 				.data(data, function(d) {
 					return d.xID + d.yID;
 				});
-			
+
 			model_rects.enter()
 				.append("rect")
 				.attr("transform", rectTranslation) // moves the data cells to region - Joe
@@ -2433,7 +2433,7 @@ var TooltipRender = require('./render.js');
 				.attr("y", function(d, i) {
 					return self._getAxisData(d.yID).ypos + self.state.yoffsetOver;
 				})
-				.attr("x", function(d) { 
+				.attr("x", function(d) {
 					return self.state.xScale(d.xID);
 				})
 				.attr("width", 10) // size of each cube - Joe
@@ -2441,18 +2441,18 @@ var TooltipRender = require('./render.js');
 				// I need to pass this into the function
 				.on("mouseover", function(d) {
 					this.parentNode.appendChild(this);
-					
+
 					self._highlightIntersection(d, d3.mouse(this));
 					self._enableRowColumnRects(this);
 					self.state.currSelectedRect = this;
-					
+
 					self._showModelData(d, this);
 				})
 				.on("mouseout", function(d) {
 					// De-highlight row and column
 					self.state.svg.selectAll(".pg_row_accent").remove();
 					self.state.svg.selectAll(".pg_col_accent").remove();
-					
+
 					// Reset model data tooltip content
 					self.state.svg.selectAll("#pg_detail_content").remove();
 
@@ -2485,7 +2485,7 @@ var TooltipRender = require('./render.js');
 				.attr("x", function(d) {
 					return self.state.xScale(d.xID) + 2; // x position of the cubes region - Joe
 				});
-			
+
 			model_rects.exit().remove();
 		},
 
@@ -2540,8 +2540,8 @@ var TooltipRender = require('./render.js');
 					border_rect.attr("x", 0);
 					border_rect.attr("y", function(d, i) {
 						totCt += ct;
-						if (i === 0) { 
-							return (self.state.yoffset + borderStroke); 
+						if (i === 0) {
+							return (self.state.yoffset + borderStroke);
 						} else {
 							parCt = totCt - ct;
 							return (self.state.yoffset + borderStroke) + ((vwidthAndGap) * parCt + i);
@@ -2550,28 +2550,28 @@ var TooltipRender = require('./render.js');
 				} else if (self.state.targetSpeciesName == 'Overview' && ! this.state.invertAxis) {
 					border_rect.attr("x", function(d, i) {
 						totCt += ct;
-						if (i === 0) { 
-							return 0; 
-						} else if (i === 1) { 
-							return width - 2; 
-						} else if (i === 2) { 
+						if (i === 0) {
+							return 0;
+						} else if (i === 1) {
+							return width - 2;
+						} else if (i === 2) {
 							return width *2 - 4; // Magic numbers to move the position - Joe
 						}
-						
+
 						else {
 							parCt = totCt - ct;
 							return hwidthAndGap * parCt;
 						}
 					})
 					.attr("width", hwidthAndGap * ct + 1); // magic number 1 makes the width a little wider - Joe
-					
+
 					border_rect.attr("y", self.state.yoffset + 1);
 				} else {
 					border_rect.attr("x", function(d, i) {
 						totCt += ct;
-						if (i === 0) { 
-							return 0; 
-						} 
+						if (i === 0) {
+							return 0;
+						}
 						else {
 							parCt = totCt - ct;
 							return hwidthAndGap * parCt;
@@ -2585,7 +2585,7 @@ var TooltipRender = require('./render.js');
 			var self = this;
 
 			var model_rects = self.state.svg.selectAll("rect.models")
-				.filter(function(d) { 
+				.filter(function(d) {
 					return d.rowid == curr_rect.__data__.rowid;
 				});
 			for (var i in model_rects[0]){
@@ -2595,7 +2595,7 @@ var TooltipRender = require('./render.js');
 				model_rects[0][i].parentNode.appendChild(model_rects[0][i]);
 			}
 			var data_rects = self.state.svg.selectAll("rect.models")
-				.filter(function(d) { 
+				.filter(function(d) {
 					return d.model_id == curr_rect.__data__.model_id;
 				});
 			for (var j in data_rects[0]){
@@ -2614,7 +2614,7 @@ var TooltipRender = require('./render.js');
 				.attr("transform", "translate(" + (self.state.axis_pos_list[1] + 2) + ","+ (self.state.yoffsetOver + 6 ) + ")") // position control -Joe
 				.attr("x", 12)
 				.attr("y", function(d) {
-					return self._getAxisData(curr_data.yID).ypos; 
+					return self._getAxisData(curr_data.yID).ypos;
 				}) //rowid
 				.attr("class", "pg_row_accent")
 				.attr("width", this.state.modelWidth - 4)
@@ -2640,7 +2640,7 @@ var TooltipRender = require('./render.js');
 			// create the related model rectangles
 			var highlight_rect2 = self.state.svg.append("svg:rect")
 				.attr("transform", "translate(" + (self.state.textWidth + self.state.xOffsetOver + 36) + "," + (self.state.yoffsetOver + 1) +  ")") // position control -Joe
-				.attr("x", function(d) { 
+				.attr("x", function(d) {
 					return (self.state.xScale(curr_data.xID) - 1);
 				})
 				.attr("y", self.state.yoffset + 2 )
@@ -2662,8 +2662,8 @@ var TooltipRender = require('./render.js');
 			this.state.h = (data.length * 2.5);
 
 			self.state.yScale = d3.scale.ordinal()
-				.domain(data.map(function(d) { 
-					return d.yID; 
+				.domain(data.map(function(d) {
+					return d.yID;
 				}))
 				.range([0,data.length])
 				.rangePoints([self.state.yModelRegion,self.state.yModelRegion + this.state.h]);
@@ -2725,7 +2725,7 @@ var TooltipRender = require('./render.js');
 
 		// Previously _clearModelLabels
 		_clearXLabels: function() {
-			// In SVG, the g element is a container used to group objects. Transformations applied to the g element are performed on all of its child elements. 
+			// In SVG, the g element is a container used to group objects. Transformations applied to the g element are performed on all of its child elements.
 			// Attributes applied are inherited by child elements. - Joe
 			this.state.svg.selectAll("g.x").remove(); // Fixed x labels overlaping - Joe
 			this.state.svg.selectAll("g .tick.major").remove(); // Can be removed? - Joe
@@ -2747,8 +2747,8 @@ var TooltipRender = require('./render.js');
 					.attr("y2", 0)
 					.attr("stroke", "#0F473E")
 					.attr("stroke-width", 1);
-			} 
-			
+			}
+
 			// Why the following? - Joe
 			this.state.svg.selectAll("path.domain").remove();
 			this.state.svg.selectAll("text.scores").remove();
@@ -2849,7 +2849,7 @@ var TooltipRender = require('./render.js');
 				.enter()
 				.append("text")
 				.attr("transform", translation)
-				.attr("x", function(d,i) { 
+				.attr("x", function(d,i) {
 					return (i + 1 / 2 ) * xPerModel;
 				})
 				.attr("id", "pg_specieslist")
@@ -2898,12 +2898,12 @@ var TooltipRender = require('./render.js');
 					draggable: true,
 					dialogClass: "faqdialog_bg_color",
 					position: {
-						my: "top", 
+						my: "top",
 						at: "top+25%",
 						of: "#pg_svg_area"
 					},
 					title: 'Phenogrid Notes',
-					
+
 					// Replace default jquery-ui titlebar close icon with font awesome - Joe
 					open: function(event, ui) {
 						// remove default close icon
@@ -2936,13 +2936,13 @@ var TooltipRender = require('./render.js');
 			var y = self.state.yModelRegion;
 			// create accent boxes
 			var rect_accents = this.state.svg.selectAll("#rect.accent")
-				.data([0,1,2], function(d) { 
+				.data([0,1,2], function(d) {
 					return d;
 				});
 			rect_accents.enter()
 				.append("rect")
 				.attr("class", "accent")
-				.attr("x", function(d, i) { 
+				.attr("x", function(d, i) {
 				    return self.state.axis_pos_list[i];
 				})
 				.attr("y", y)
@@ -2999,7 +2999,7 @@ var TooltipRender = require('./render.js');
 
 			this.state.xScale = d3.scale.ordinal()
 				.domain(mods.map(function (d) {
-					return d; 
+					return d;
 				}))
 				.rangeRoundBands([0,this.state.modelWidth]);
 
@@ -3035,7 +3035,7 @@ var TooltipRender = require('./render.js');
 		_addGradients: function() {
 			var self = this;
 			var modData = this.state.modelDataHash.values();
-			var temp_data = modData.map(function(d) { 
+			var temp_data = modData.map(function(d) {
 				return d.value[self.state.selectedCalculation];
 			});
 			var diff = d3.max(temp_data) - d3.min(temp_data);
@@ -3060,7 +3060,7 @@ var TooltipRender = require('./render.js');
 			var y;
 			// If this is the Overview, get gradients for all species with an index
 			// COMPARE CALL HACK - REFACTOR OUT
-			if ((this.state.targetSpeciesName == 'Overview' || this.state.targetSpeciesName == 'All') 
+			if ((this.state.targetSpeciesName == 'Overview' || this.state.targetSpeciesName == 'All')
 				|| (this.state.targetSpeciesName == "Homo sapiens" && (this.state.owlSimFunction == "compare" || this.state.owlSimFunction == "exomiser"))) {
 				//this.state.overviewCount tells us how many fit in the overview
 				for (var i = 0; i < this.state.overviewCount; i++) {
@@ -3098,7 +3098,7 @@ var TooltipRender = require('./render.js');
 				.attr("x2", "100%")
 				.attr("y1", "0%")
 				.attr("y2", "0%");
-			
+
 			for (var j in this.state.colorDomains) {
 				if ( ! this.state.colorDomains.hasOwnProperty(j)) {
 					break;
@@ -3106,7 +3106,7 @@ var TooltipRender = require('./render.js');
 				gradient.append("svg:stop")
 					.attr("offset", this.state.colorDomains[j])
 					.style("stop-color", this.state.colorRanges[i][j])
-					.style("stop-opacity", 1); 
+					.style("stop-opacity", 1);
 			}
 
 			// gradient + gap is 20 pixels
@@ -3250,9 +3250,9 @@ var TooltipRender = require('./render.js');
 				"\" " + selectedItem + ">" + this.state.targetSpeciesList[idx].name + "</option>";
 			}
 			// add one for overview.
-			
+
 			// Overview is not a proper name, change it later - Joe
-			
+
 			if (this.state.targetSpeciesName === 'Overview') {
 				selectedItem = 'selected';
 			} else {
@@ -3323,10 +3323,10 @@ var TooltipRender = require('./render.js');
 			list = self._getSortedIDListStrict(self.state.filteredYAxis.entries());
 
 			// Updating nodes - Joe
-			var rect_text = this.state.svg.selectAll(".a_text").data(list, function(d) { 
-					return d; 
+			var rect_text = this.state.svg.selectAll(".a_text").data(list, function(d) {
+					return d;
 				});
-			
+
 			// Enter, create new nodes for incoming data - Joe
 			rect_text.enter()
 				.append("text")
@@ -3349,7 +3349,7 @@ var TooltipRender = require('./render.js');
 				.on("mouseover", function(d) {
 					self._selectYItem(d, d3.mouse(this));
 				})
-				.on("mouseout", function(d) { 
+				.on("mouseout", function(d) {
 					self._deselectData(d, d3.mouse(this));
 				})
 				.attr("data-tooltip", "sticky1")
@@ -3386,7 +3386,7 @@ var TooltipRender = require('./render.js');
 			var tempObject = {"id": 0, "observed": "positive"};
 
 			for (var i in fullset) {
-				if ( ! fullset.hasOwnProperty(i)) { 
+				if ( ! fullset.hasOwnProperty(i)) {
 					break;
 				}
 				if (typeof(fullset[i].id) === 'undefined') {
@@ -3562,8 +3562,8 @@ var TooltipRender = require('./render.js');
 				hpoData += "<strong>IC:</strong> " + info.IC.toFixed(2) + "<br/><br/>";
 
 				var hpoTree = this.buildHPOTree(id.replace("_", ":"), hpoCached.edges, 0);
-				
-	
+
+
 				if (hpoTree == "<br/>") {
 					hpoData += "<em>No HPO Data Found</em>";
 				} else {
@@ -3576,7 +3576,7 @@ var TooltipRender = require('./render.js');
 			}
 		},
 
-		// Will hide the hpo info, not delete it.  
+		// Will hide the hpo info, not delete it.
 		// This allows for reloading to be done faster and avoid unneeded server calls.  Not available if preloading
 		_collapseHPO: function(id) {
 			var idClean = id.replace("_", ":");
@@ -3586,8 +3586,8 @@ var TooltipRender = require('./render.js');
 			stickytooltip.closetooltip();
 		},
 
-		// When provided with an ID, it will first check hpoCacheHash if currently has the HPO data stored, 
-		// and if it does it will set it to be visible.  If it does not have that information in the hpoCacheHash, 
+		// When provided with an ID, it will first check hpoCacheHash if currently has the HPO data stored,
+		// and if it does it will set it to be visible.  If it does not have that information in the hpoCacheHash,
 		// it will make a server call to get the information and if successful will parse the information into hpoCacheHash and hpoCacheLabels
 		_getHPO: function(id) {
 			// check cached hashtable first
@@ -3612,11 +3612,11 @@ var TooltipRender = require('./render.js');
 						if ( ! nodes.hasOwnProperty(i)) {
 							break;
 						}
-						if ( ! this.state.hpoCacheLabels.containsKey(nodes[i].id) 
-							&& (nodes[i].id != "MP:0000001" 
-							&& nodes[i].id != "OBO:UPHENO_0001001" 
-							&& nodes[i].id != "OBO:UPHENO_0001002" 
-							&& nodes[i].id != "HP:0000118" 
+						if ( ! this.state.hpoCacheLabels.containsKey(nodes[i].id)
+							&& (nodes[i].id != "MP:0000001"
+							&& nodes[i].id != "OBO:UPHENO_0001001"
+							&& nodes[i].id != "OBO:UPHENO_0001002"
+							&& nodes[i].id != "HP:0000118"
 							&& nodes[i].id != "HP:0000001")) {
 							this.state.hpoCacheLabels.put(nodes[i].id, this._capitalizeString(nodes[i].lbl));
 						}
@@ -3627,10 +3627,10 @@ var TooltipRender = require('./render.js');
 						if ( ! edges.hasOwnProperty(j)) {
 							break;
 						}
-						if (edges[j].obj != "MP:0000001" 
-							&& edges[j].obj != "OBO:UPHENO_0001001" 
-							&& edges[j].obj != "OBO:UPHENO_0001002" 
-							&& edges[j].obj != "HP:0000118" 
+						if (edges[j].obj != "MP:0000001"
+							&& edges[j].obj != "OBO:UPHENO_0001001"
+							&& edges[j].obj != "OBO:UPHENO_0001002"
+							&& edges[j].obj != "HP:0000118"
 							&& edges[j].obj != "HP:0000001") {
 							HPOInfo.push(edges[j]);
 						}
@@ -3962,7 +3962,7 @@ var TooltipRender = require('./render.js');
 		_rebuildModelHash: function() {
 			// [vaa12] needs updating based on changes in finishLoad and finishOverviewLoad
 			this.state.phenotypeListHash = new Hashtable();
-			
+
 			// Create a new empty hash table with supplied options, Hashtable(Object options) - Joe
 			this.state.modelDataHash = new Hashtable({hashCode: model.modelDataPointPrint, equals: model.modelDataPointEquals});
 			var modelPoint, hashData;
@@ -3992,7 +3992,7 @@ var TooltipRender = require('./render.js');
 			}
 		},
 
-		
+
 		// According to harry, not showing in current master version - Joe
 		_getAssociatedGenotypes: function(curModel) {
 			// check cached hashtable first

--- a/package.json
+++ b/package.json
@@ -1,47 +1,47 @@
 {
-    "name":"phenogrid",
-    "version":"0.0.2",
-    "description":"Monarch PhenoGrid widget",
-    "repository":{
-        "type":"git",
-        "url":"https://github.com/monarch-initiative/phenogrid.git"
-    },
-    "keywords":[
-        "monarch",
-        "phenogrid",
-        "widget",
-        "visualization"
-    ],
-    "author":"University of Pittsburgh, Department of Biomedical Informatics",
-    "license":"ISC",
-    "bugs":{
-        "url":"https://github.com/monarch-initiative/phenogrid/issues"
-    },
-    "homepage":"https://github.com/monarch-initiative/phenogrid",
-    "dependencies":{
-        "d3":"^3.5.5",
-        "jquery":"^2.1.4",
-        "jquery-ui":"^1.10.5",
-        "jshashtable":"^0.1.0",
-		"npm": "^2.12.1",
-        "vinyl-source-stream":"^1.1.0"
-    },
-    "devDependencies":{
-        "browserify":"^10.2.1",
-        "chai":"^2.3.0",
-        "del":"^1.1.1",
-        "gulp":"^3.8.11",
-        "gulp-bump":"^0.3.0",
-        "gulp-concat":"^2.5.2",
-        "gulp-git":"^1.2.3",
-        "gulp-jsdoc":"^0.1.4",
-        "gulp-mocha":"^2.0.1",
-        "gulp-pandoc":"^0.2.1",
-        "gulp-rename":"^1.2.2",
-        "gulp-shell":"^0.4.2",
-        "gulp-uglify":"^1.2.0",
-        "jsdoc":"^3.3.0",
-        "jsdoc-baseline":"git://github.com/hegemonic/jsdoc-baseline.git#74d1dc8075"
-    },
-    "main":"js/phenogrid.js"
+  "name": "phenogrid",
+  "version": "0.0.2",
+  "description": "Monarch PhenoGrid widget",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/monarch-initiative/phenogrid.git"
+  },
+  "keywords": [
+    "monarch",
+    "phenogrid",
+    "widget",
+    "visualization"
+  ],
+  "author": "University of Pittsburgh, Department of Biomedical Informatics",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/monarch-initiative/phenogrid/issues"
+  },
+  "homepage": "https://github.com/monarch-initiative/phenogrid",
+  "dependencies": {
+    "d3": "^3.5.5",
+    "gfm.css": "^1.1.1",
+    "jquery": "^2.1.4",
+    "jquery-ui": "^1.10.5",
+    "jshashtable": "^0.1.0",
+    "npm": "^2.12.1",
+    "vinyl-source-stream": "^1.1.0"
+  },
+  "devDependencies": {
+    "browserify": "^10.2.1",
+    "chai": "^2.3.0",
+    "del": "^1.1.1",
+    "gulp": "^3.8.11",
+    "gulp-bump": "^0.3.0",
+    "gulp-concat": "^2.5.2",
+    "gulp-file-include": "^0.13.5",
+    "gulp-git": "^1.2.3",
+    "gulp-mocha": "^2.0.1",
+    "gulp-pandoc": "^0.2.1",
+    "gulp-rename": "^1.2.2",
+    "gulp-shell": "^0.4.2",
+    "gulp-uglify": "^1.2.0",
+    "marked": "^0.3.3"
+  },
+  "main": "js/phenogrid.js"
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,66 @@
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Monarch Phenotype Grid Widget</title>
+
+<!--
+<style type="text/css">
+/* ==========================================================================
+   Print styles.
+   Inlined to avoid required HTTP connection: h5bp.com/r
+   ========================================================================== */
+@@include('../css/print.css')
+
+</style>
+-->
+
+<script src="config/phenogrid_config.js"></script>
+<script src="dist/phenogrid-bundle.js"></script>
+
+<link rel="stylesheet" type="text/css" href="dist/phenogrid-bundle.css">
+
+<script>
+var phenotypes = [
+    {id:"HP:0000726", observed:"positive"},
+    {id:"HP:0000746", observed:"positive"},
+    {id:"HP:0001300", observed:"positive"},
+    {id:"HP:0002367", observed:"positive"},
+    {id:"HP:0000012", observed:"positive"},
+    {id:"HP:0000716", observed:"positive"},
+    {id:"HP:0000726", observed:"positive"},
+    {id:"HP:0000739", observed:"positive"},
+    {id:"HP:0001332", observed:"positive"},
+    {id:"HP:0001347", observed:"positive"},
+    {id:"HP:0002063", observed:"positive"},
+    {id:"HP:0002067", observed:"positive"},
+    {id:"HP:0002172", observed:"positive"},
+    {id:"HP:0002322", observed:"positive"},
+    {id:"HP:0007159", observed:"positive"}
+];
+
+window.onload = function() {
+    Phenogrid.createPhenogridForElement(document.getElementById('phenogrid_container'), {
+        serverURL : "http://beta.monarchinitiative.org",
+        phenotypeData: phenotypes,
+        targetSpeciesName: "Mus musculus"
+    });
+}
+</script>
+
+</head>
+
+<body>
+
+<div class="pg_index">
+
+<div id="phenogrid_container" class="clearfix"></div>
+
+<link rel="stylesheet" type="text/css" href="node_modules/gfm.css/gfm.css">
+<div style="padding:1%;margin:1%;border:1px solid lightgray;">
+<article class="markdown-body">
+@@include(marked('../README.md'))
+</article>
+<div/>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes gulp workflow and index.html so that README.md is the authoritative documentation, and that it is rendered into the example index.html, which is generated from templates/index.html via the gulp-include-plugin.

Updated the README to eliminate mention of jQuery. Clients should not have to know about jQuery; it is a currently implementation detail that no longer leaks out of the Phenogrid abstraction.

Deletes jsdoc usage. The README.md should be sufficient unless we have a richer API to expose (currently we expose a single function).

Also adds GFM CSS for use in the generated index.html. (Hopefully this will not intrude on Phenogrid's CSS; so far, it looks OK).

Moves the inlined print CSS into a separate file, but disables it until I understand why this was done in the first place. If we reenable it and there are good reasons for not using LINK and instead inlining it, I have prepped it to use the gulp-include-plugin.

