### PR TITLE
Fixes bug when comparing to one target, removes fragment/curie switching

### DIFF
--- a/js/dataloader.js
+++ b/js/dataloader.js
@@ -762,7 +762,7 @@ DataLoader.prototype = {
 
 		// http://monarchinitiative.org/neighborhood/HP_0003273/2/OUTGOING/subClassOf.json is the URL path - Joe
 
-		var url = this.serverURL + parent.state.ontologyQuery + id.replace('_', ':') + "/" + depth + "/" + direction + "/" + relationship + ".json";
+		var url = this.serverURL + parent.state.ontologyQuery + id + "/" + depth + "/" + direction + "/" + relationship + ".json";
 
 		var cb = this.postOntologyCb;
 
@@ -782,7 +782,7 @@ DataLoader.prototype = {
     getNewTargetGroupItems: function(id, finalCallback, parent) {
         var self = this;
         // http://monarchinitiative.org/gene/MGI:98297/genotype_list.json
-        var url = this.serverURL + "/gene/" + id.replace('_', ':') + "/genotype_list.json";
+        var url = this.serverURL + "/gene/" + id + "/genotype_list.json";
         var cb = this.getNewTargetGroupItemsCb;
         // ajax get all the genotypes of this gene id
         this.getFetch(self, url, id, cb, finalCallback, parent);
@@ -866,7 +866,7 @@ DataLoader.prototype = {
         // there's no results.b is no matches found in the simsearch - Joe
         if (typeof(results.b) !== 'undefined') {
             for (var i = 0; i < results.b.length; i++) {
-                genotype_id_list.push(results.b[i].id.replace(':', '_'));
+                genotype_id_list.push(results.b[i].id);
             }
 
             // for reactivation

--- a/js/phenogrid.js
+++ b/js/phenogrid.js
@@ -1742,7 +1742,6 @@ var images = require('./images.json');
 
         // Returns axis data from a ID of models or phenotypes
         _getAxisData: function(key) {
-            key = key.replace(":", "_");  // keys are stored with _ not : in AxisGroups
             if (this.state.yAxisRender.contains(key)) {
                 return this.state.yAxisRender.get(key);
             } else if (this.state.xAxisRender.contains(key)) {
@@ -2012,7 +2011,7 @@ var images = require('./images.json');
                 //HACKISH, BUT WORKS FOR NOW.  LIMITERS THAT ALLOW FOR TREE CONSTRUCTION BUT DONT NEED TO BE PASSED BETWEEN RECURSIONS
                 this.state.ontologyTreesDone = 0;
                 this.state.ontologyTreeHeight = 0;
-                var tree = '<div id="' + this.state.pgInstanceId + '_hpoDiv">' + this._buildOntologyTree(id.replace("_", ":"), cached.edges, 0) + '</div>';
+                var tree = '<div id="' + this.state.pgInstanceId + '_hpoDiv">' + this._buildOntologyTree(id, cached.edges, 0) + '</div>';
                 if (tree === "<br>"){
                     ontologyData += "<em>No Classification hierarchy Found</em>";
                 } else {
@@ -3035,7 +3034,7 @@ var images = require('./images.json');
 
             // Normalize. E.g., HP_0000252 -> HP:0000252
             for (var j in matchedList){
-                normalizedMatchedList.push(matchedList[j].replace("_", ":"));
+                normalizedMatchedList.push(matchedList[j]);
             }
 
             // Now origSourceList should contain all elements that are in normalizedMatchedList
@@ -3171,7 +3170,7 @@ var images = require('./images.json');
             ontologyData += "<strong>Sum:</strong> " + info.sum.toFixed(2) + "<br>";
             ontologyData += "<strong>Frequency:</strong> " + info.count + "<br><br>";
 
-            var classTree = parent._buildOntologyTree(id.replace("_", ":"), d.edges, 0);
+            var classTree = parent._buildOntologyTree(id, d.edges, 0);
 
             if (classTree === "<br>"){
                 ontologyData += "<em>No classification hierarchy data found</em>";

--- a/js/phenogrid.js
+++ b/js/phenogrid.js
@@ -567,7 +567,14 @@ var images = require('./images.json');
                     targetList = this.state.dataManager.getData("target", singleTargetGroupName);
                 }
                 
-                this.state.targetDisplayLimit = this.state.dataManager.length("target", singleTargetGroupName);	
+                this.state.targetDisplayLimit = this.state.dataManager.length("target", singleTargetGroupName);
+                
+                // Determines the count shown in the column header
+                // ie mouse (>100)
+                this.state.targetTotalReturnedPerGroup = [{
+                    groupName: singleTargetGroupName,
+                    targetLength: Object.keys(targetList).length
+                }];
 
                 // In single target mode, use singleTargetModeTargetLengthLimit if more than that
                 if (this.state.targetDisplayLimit > this.state.singleTargetModeTargetLengthLimit) {

--- a/js/phenogrid.js
+++ b/js/phenogrid.js
@@ -890,7 +890,7 @@ var images = require('./images.json');
 							// this passed to _mouseover refers to the current element
 							// _mouseover() highlights and matching x/y labels, and creates crosshairs on current grid cell
 							// _mouseover() also triggers the tooltip popup as well as the tooltip mouseover/mouseleave - Joe
-						    if (self.state.selectedCompareTargetGroup.length !== 1) {
+						    if (self.state.owlSimFunction === 'search' && self.state.targetSpecies === 'all') {
 						        self._mouseover(this, d, self);
 						    }
 						})

--- a/js/phenogrid.js
+++ b/js/phenogrid.js
@@ -890,7 +890,10 @@ var images = require('./images.json');
 							// this passed to _mouseover refers to the current element
 							// _mouseover() highlights and matching x/y labels, and creates crosshairs on current grid cell
 							// _mouseover() also triggers the tooltip popup as well as the tooltip mouseover/mouseleave - Joe
-							self._mouseover(this, d, self);})
+						    if (self.state.selectedCompareTargetGroup.length !== 1) {
+						        self._mouseover(this, d, self);
+						    }
+						})
 						.on("mouseout", function(d) {
 							// _mouseout() removes the matching highlighting as well as the crosshairs - Joe
 							self._mouseout();

--- a/js/utils.js
+++ b/js/utils.js
@@ -9,7 +9,6 @@ var Utils = {
 			var retString = uri;
 			try {
 				retString = retString.replace(" ", "_");
-				retString = retString.replace(":", "_");
 				return retString;
 			} catch (exception) {}
 	},


### PR DESCRIPTION
This PR fixes the bug related to displaying column counts when there is a single target.  It also removes the target type tooltip when there is one target (otherwise a message appears that says "show results for all species."   It also removes all of the code that switches an ID between curie and fragment syntaxes. 

Note to determine if we have searched for >1 target I am using:
if (self.state.owlSimFunction === 'search' && self.state.targetSpecies === 'all') {}

which seems suboptimal, @yuanzhou @cborromeo is there a better way?

Also when setting a limit of 100, the result count currently shows (>100), is this intended?  If not it would be easy to fix.

Fixes https://github.com/monarch-initiative/phenogrid/issues/259
Fixes https://github.com/monarch-initiative/monarch-app/issues/1391